### PR TITLE
Because react-native is insane

### DIFF
--- a/SpokeStack/AppleWakewordRecognizer.swift
+++ b/SpokeStack/AppleWakewordRecognizer.swift
@@ -12,37 +12,40 @@ import Speech
 public class AppleWakewordRecognizer: NSObject, WakewordRecognizerService {
 
     // MARK: public properties
-    
+
     static let sharedInstance: AppleWakewordRecognizer = AppleWakewordRecognizer()
     public var configuration: WakewordConfiguration = WakewordConfiguration()
     public weak var delegate: WakewordRecognizer?
-    
+
     // MARK: wakeword properties
-    
+
     private var phrases: Array<String> = []
-    
+
     // MARK: recognition properties
-    
+
     private let audioSession: AVAudioSession = AVAudioSession.sharedInstance()
     private let speechRecognizer: SFSpeechRecognizer = SFSpeechRecognizer(locale: NSLocale.current)!
-    private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest = SFSpeechAudioBufferRecognitionRequest()
+    private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
     private var recognitionTask: SFSpeechRecognitionTask?
     private let audioEngine: AVAudioEngine = AVAudioEngine()
     private var dispatchWorker: DispatchWorkItem?
-    
+
     // MARK: NSObject methods
-    
+
     deinit {
         speechRecognizer.delegate = nil
+        recognitionRequest = nil
     }
-    
+
     public override init() {
         super.init()
+        recognitionRequest = SFSpeechAudioBufferRecognitionRequest()
+        recognitionRequest?.shouldReportPartialResults = true
         phrases = self.configuration.wakePhrases.components(separatedBy: ",")
     }
-    
+
     // MARK: SpeechRecognizerService implementation
-    
+
     func startStreaming(context: SpeechContext) {
         do {
             try self.prepareRecognition(context: context)
@@ -52,25 +55,21 @@ public class AppleWakewordRecognizer: NSObject, WakewordRecognizerService {
             self.delegate?.didError(error)
         }
     }
-    
+
     func stopStreaming(context: SpeechContext) {
         audioEngine.stop()
         self.audioEngine.inputNode.removeTap(onBus: 0)
         recognitionTask?.cancel()
-        recognitionRequest.endAudio()
+        recognitionRequest?.endAudio()
         recognitionTask = nil
     }
-    
+
     // MARK: private functions
-    
+
     private func prepareRecognition(context: SpeechContext) throws -> Void {
 
-        // MARK: recognitionRequest
-
-        recognitionRequest.shouldReportPartialResults = true
-        
         // MARK: AVAudioEngine
-        
+
         let buffer: Int = (self.configuration.sampleRate / 1000) * self.configuration.frameWidth
         let recordingFormat = self.audioEngine.inputNode.outputFormat(forBus: 0)
         self.audioEngine.inputNode.removeTap(onBus: 0) // a belt-and-suspenders approach to fixing https://github.com/wenkesj/react-native-voice/issues/46
@@ -82,7 +81,7 @@ public class AppleWakewordRecognizer: NSObject, WakewordRecognizerService {
             guard let strongSelf = self else {
                 return
             }
-            strongSelf.recognitionRequest.append(buffer)
+            strongSelf.recognitionRequest?.append(buffer)
         }
         
         // MARK: Automatically restart wakeword task if it goes over Apple's 1 minute listening limit
@@ -95,33 +94,33 @@ public class AppleWakewordRecognizer: NSObject, WakewordRecognizerService {
         // MARK: recognitionTask
         
         self.recognitionTask = self.speechRecognizer.recognitionTask(
-            with: recognitionRequest,
+            with: recognitionRequest!,
             resultHandler: {[weak self] result, error in
-            guard let strongSelf = self else {
-                return
-            }
-            if let e = error {
-                /*
-                 A `Error Domain=kAFAssistantErrorDomain Code=216 "(null)"` (although sometimes it’s a `209` instead of `216`) happens in this `recognitionTask` callback that occurs _after_ `stopStreaming`. I’ve verified that `stopStreaming` does everything it’s supposed to in the order it’s supposed to. The error doesn’t seem to affect anything (and other people report the same https://stackoverflow.com/questions/53037789/sfspeechrecognizer-216-error-with-multiple-requests?noredirect=1&lq=1)
-                 */
-                strongSelf.delegate?.didError(e)
-            }
-            if let r = result {
-                let wakewordDetected: Bool =
-                    !strongSelf.phrases
-                        .filter({
-                            r
-                                .bestTranscription
-                                .formattedString
-                                .lowercased()
-                                .contains($0.lowercased())})
-                        .isEmpty
-                if wakewordDetected {
-                    strongSelf.dispatchWorker?.cancel()
-                    strongSelf.stopStreaming(context: context)
-                    strongSelf.delegate?.activate()
+                guard let strongSelf = self else {
+                    return
                 }
-            }
+                if let e = error {
+                    /*
+                     A `Error Domain=kAFAssistantErrorDomain Code=216 "(null)"` (although sometimes it’s a `209` instead of `216`) happens in this `recognitionTask` callback that occurs _after_ `stopStreaming`. I’ve verified that `stopStreaming` does everything it’s supposed to in the order it’s supposed to. The error doesn’t seem to affect anything (and other people report the same https://stackoverflow.com/questions/53037789/sfspeechrecognizer-216-error-with-multiple-requests?noredirect=1&lq=1)
+                     */
+                    strongSelf.delegate?.didError(e)
+                }
+                if let r = result {
+                    let wakewordDetected: Bool =
+                        !strongSelf.phrases
+                            .filter({
+                                r
+                                    .bestTranscription
+                                    .formattedString
+                                    .lowercased()
+                                    .contains($0.lowercased())})
+                            .isEmpty
+                    if wakewordDetected {
+                        strongSelf.dispatchWorker?.cancel()
+                        strongSelf.stopStreaming(context: context)
+                        strongSelf.delegate?.activate()
+                    }
+                }
         })
     }
 }


### PR DESCRIPTION
React Native will repeatedly call an instance of AppleSpeechRecognizer/AppleWakewordRecognizer, unlike the swift example app. This causes an assertion failure in `SFSpeechAudioBufferRecognitionRequest` for `SFSpeechAudioBufferRecognitionRequest cannot be re-used`. We can use the class' shared instance to protect the creation of `SFSpeechAudioBufferRecognitionRequest`.