### PR TITLE
didFinish -> deactivate; AudioController logic fix

### DIFF
--- a/SpokeStack/AppleSpeechRecognizer.swift
+++ b/SpokeStack/AppleSpeechRecognizer.swift
@@ -101,7 +101,7 @@ class AppleSpeechRecognizer: NSObject, SpeechRecognizerService {
                             case 203: // request timed out, retry
                                 print("AppleSpeechRecognizer createRecognitionTask resultHandler error 203")
                                 context.isActive = false
-                                strongSelf.delegate?.didFinish()
+                                strongSelf.delegate?.deactivate()
                                 break
                             case 209: // ¯\_(ツ)_/¯
                                 print("AppleSpeechRecognizer createRecognitionTask resultHandler error 209")
@@ -128,7 +128,7 @@ class AppleSpeechRecognizer: NSObject, SpeechRecognizerService {
                         print("AppleSpeechRecognizer dispatchWorker")
                         context.isActive = false
                         self?.delegate?.didRecognize(context)
-                        self?.delegate?.didFinish()
+                        self?.delegate?.deactivate()
                     }
                     DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .milliseconds(strongSelf.configuration.vadFallDelay), execute: strongSelf.dispatchWorker!)
                 }

--- a/SpokeStack/AppleSpeechRecognizer.swift
+++ b/SpokeStack/AppleSpeechRecognizer.swift
@@ -19,7 +19,6 @@ class AppleSpeechRecognizer: NSObject, SpeechRecognizerService {
     
     // MARK: private properties
     
-    private let audioSession: AVAudioSession = AVAudioSession.sharedInstance()
     private let speechRecognizer: SFSpeechRecognizer = SFSpeechRecognizer(locale: NSLocale.current)!
     private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
     private var recognitionTask: SFSpeechRecognitionTask?

--- a/SpokeStack/AppleWakewordRecognizer.swift
+++ b/SpokeStack/AppleWakewordRecognizer.swift
@@ -23,7 +23,6 @@ public class AppleWakewordRecognizer: NSObject, WakewordRecognizerService {
     
     // MARK: recognition properties
     
-    private let audioSession: AVAudioSession = AVAudioSession.sharedInstance()
     private let speechRecognizer: SFSpeechRecognizer = SFSpeechRecognizer(locale: NSLocale.current)!
     private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
     private var recognitionTask: SFSpeechRecognitionTask?

--- a/SpokeStack/AudioController.swift
+++ b/SpokeStack/AudioController.swift
@@ -140,6 +140,7 @@ class AudioController {
     }
 
     func beginAudioSession() throws {
+        print("AudioController beginAudioSession")
         // TODO: https://developer.apple.com/documentation/avfoundation/avaudiosession/responding_to_audio_session_route_changes
         let session: AVAudioSession = AVAudioSession.sharedInstance()
         self.priorAudioSessionCategory = session.category
@@ -156,12 +157,13 @@ class AudioController {
     }
 
     func endAudioSession() throws {
+        print("AudioController endAudioSession")
         let session: AVAudioSession = AVAudioSession.sharedInstance()
         do {
             if !(session.category == self.priorAudioSessionCategory) {
                 try session.setCategory(self.priorAudioSessionCategory!, mode: self.priorAudioSessionMode!, options: self.priorAudioSessionCategoryOptions!)
             }
-            try session.setActive(true, options: .notifyOthersOnDeactivation)
+            try session.setActive(false, options: .notifyOthersOnDeactivation)
         } catch {
             throw AudioError.audioSessionSetup(error.localizedDescription)
         }

--- a/SpokeStack/GoogleSpeechRecognizer.swift
+++ b/SpokeStack/GoogleSpeechRecognizer.swift
@@ -108,7 +108,7 @@ public class GoogleSpeechRecognizer: SpeechRecognizerService {
                                                                 
                                                                 guard let strongSelf = self, error == nil else {
                                                                     self?.delegate?.didError(error ?? SpeechRecognizerError.unknownCause("no error description provided"))
-                                                                    self?.delegate?.didFinish()
+                                                                    self?.delegate?.deactivate()
                                                                     return
                                                                 }
                                                                 
@@ -124,7 +124,7 @@ public class GoogleSpeechRecognizer: SpeechRecognizerService {
                                                                         strongSelf.context.transcript = alt.transcript
                                                                         strongSelf.context.confidence = alt.confidence
                                                                         strongSelf.delegate?.didRecognize(strongSelf.context)
-                                                                        strongSelf.delegate?.didFinish()
+                                                                        strongSelf.delegate?.deactivate()
                                                                         strongSelf.stopStreaming(context: strongSelf.context)
                                                                     }
                                                                 }

--- a/SpokeStack/SpeechPipeline.swift
+++ b/SpokeStack/SpeechPipeline.swift
@@ -64,11 +64,11 @@ import Foundation
     
     @objc public func deactivate() -> Void {
         self.speechRecognizerService.stopStreaming(context: self.context)
+        self.wakewordRecognizerService.startStreaming(context: self.context)
     }
     
     @objc public func start() -> Void {
         AudioController.shared.startStreaming(context: self.context)
-        self.speechRecognizerService.stopStreaming(context: self.context)
         self.wakewordRecognizerService.startStreaming(context: self.context)
     }
     

--- a/SpokeStack/SpeechRecognizer.swift
+++ b/SpokeStack/SpeechRecognizer.swift
@@ -14,7 +14,7 @@ import Foundation
     
     func didRecognize(_ result: SpeechContext) -> Void
     
-    func didFinish() -> Void
+    func deactivate() -> Void
     
     func didError(_ error: Error) -> Void
 }

--- a/SpokeStackFrameworkExample/AppleViewController.swift
+++ b/SpokeStackFrameworkExample/AppleViewController.swift
@@ -103,21 +103,17 @@ extension AppleViewController: SpeechRecognizer, WakewordRecognizer {
     }
     
     func deactivate() {
-        
+        print("deactivate")
+        self.stopRecordingButton.isEnabled.toggle()
+        self.startRecordingButton.isEnabled.toggle()
     }
     
     func didError(_ error: Error) {
-        print("didFinish \(String(describing: error))")
+        print("didError \(String(describing: error))")
     }
     
     func didRecognize(_ result: SpeechContext) {
         print("didRecognize transcript \(result.transcript)")
-    }
-    
-    func didFinish() {
-        print("didFinish")
-        self.stopRecordingButton.isEnabled.toggle()
-        self.startRecordingButton.isEnabled.toggle()
     }
     
     func didStart() {

--- a/SpokeStackFrameworkExample/GoogleViewController.swift
+++ b/SpokeStackFrameworkExample/GoogleViewController.swift
@@ -104,21 +104,16 @@ extension GoogleViewController: SpeechRecognizer, WakewordRecognizer {
     }
     
     func deactivate() {
-        
+        self.stopRecordingButton.isEnabled.toggle()
+        self.startRecordingButton.isEnabled.toggle()
     }
     
-    
     func didError(_ error: Error) {
-        print("didFinish \(String(describing: error))")
+        print("didError \(String(describing: error))")
     }
     
     func didRecognize(_ result: SpeechContext) {
         print("transcript \(result.transcript)")
-    }
-    
-    func didFinish() {
-        self.stopRecordingButton.isEnabled.toggle()
-        self.startRecordingButton.isEnabled.toggle()
     }
     
     func didStart() {

--- a/SpokeStackFrameworkExample/WakeWordViewController.swift
+++ b/SpokeStackFrameworkExample/WakeWordViewController.swift
@@ -98,6 +98,7 @@ extension WakeWordViewController: SpeechRecognizer, WakewordRecognizer {
     
     func deactivate() {
         print("deactivate")
+        self.pipeline.deactivate()
     }
     
     func didError(_ error: Error) {
@@ -108,11 +109,6 @@ extension WakeWordViewController: SpeechRecognizer, WakewordRecognizer {
     
     func didRecognize(_ result: SpeechContext) {
         print("didRecognize \(result.transcript)")
-    }
-    
-    func didFinish() {
-        print("didFinish")
-        self.pipeline.deactivate()
     }
     
     func didStart() {

--- a/SpokeStackFrameworkExample/WakeWordViewController.swift
+++ b/SpokeStackFrameworkExample/WakeWordViewController.swift
@@ -112,11 +112,7 @@ extension WakeWordViewController: SpeechRecognizer, WakewordRecognizer {
     
     func didFinish() {
         print("didFinish")
-        if (self.pipeline.context.isActive) {
-            self.pipeline.activate()
-        } else {
-            self.pipeline.start()
-        }
+        self.pipeline.deactivate()
     }
     
     func didStart() {


### PR DESCRIPTION
`didFinish` -> `deactivate` better matches the semantics of other parts of spokestack, where `deactivate` indicates that ASR is complete and wakeword should be reactivated.