### PR TITLE
Support for timedOut event upon ASR timeout without detecting speech

### DIFF
--- a/SpokeStack/AppleSpeechRecognizer.swift
+++ b/SpokeStack/AppleSpeechRecognizer.swift
@@ -53,7 +53,7 @@ class AppleSpeechRecognizer: NSObject, SpeechRecognizerService {
             self.wakeActveMaxWorker = DispatchWorkItem {[weak self] in
                 print("AppleSpeechRecognizer wakeActveMaxWorker")
                 context.isActive = false
-                self?.delegate?.didRecognize(context)
+                self?.delegate?.timedOut()
                 self?.delegate?.deactivate()
             }
             DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(self.configuration!.wakeActiveMax), execute: self.wakeActveMaxWorker!)

--- a/SpokeStack/AppleSpeechRecognizer.swift
+++ b/SpokeStack/AppleSpeechRecognizer.swift
@@ -53,7 +53,7 @@ class AppleSpeechRecognizer: NSObject, SpeechRecognizerService {
             self.wakeActiveMaxWorker = DispatchWorkItem {[weak self] in
                 print("AppleSpeechRecognizer wakeActiveMaxWorker")
                 context.isActive = false
-                self?.delegate?.timedOut()
+                self?.delegate?.timeout()
                 self?.delegate?.deactivate()
             }
             DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(self.configuration!.wakeActiveMax), execute: self.wakeActiveMaxWorker!)

--- a/SpokeStack/AppleSpeechRecognizer.swift
+++ b/SpokeStack/AppleSpeechRecognizer.swift
@@ -24,7 +24,7 @@ class AppleSpeechRecognizer: NSObject, SpeechRecognizerService {
     private var recognitionTask: SFSpeechRecognitionTask?
     private let audioEngine: AVAudioEngine = AVAudioEngine()
     private var vadFallWorker: DispatchWorkItem?
-    private var wakeActveMaxWorker: DispatchWorkItem?
+    private var wakeActiveMaxWorker: DispatchWorkItem?
     
     // MARK: NSObject methods
     
@@ -50,13 +50,13 @@ class AppleSpeechRecognizer: NSObject, SpeechRecognizerService {
             try self.createRecognitionTask(context: context)
             self.audioEngine.prepare()
             try self.audioEngine.start()
-            self.wakeActveMaxWorker = DispatchWorkItem {[weak self] in
-                print("AppleSpeechRecognizer wakeActveMaxWorker")
+            self.wakeActiveMaxWorker = DispatchWorkItem {[weak self] in
+                print("AppleSpeechRecognizer wakeActiveMaxWorker")
                 context.isActive = false
                 self?.delegate?.timedOut()
                 self?.delegate?.deactivate()
             }
-            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(self.configuration!.wakeActiveMax), execute: self.wakeActveMaxWorker!)
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(self.configuration!.wakeActiveMax), execute: self.wakeActiveMaxWorker!)
         } catch let error {
             self.delegate?.didError(error)
         }
@@ -69,7 +69,7 @@ class AppleSpeechRecognizer: NSObject, SpeechRecognizerService {
         self.recognitionRequest?.endAudio()
         self.recognitionRequest = nil
         self.vadFallWorker?.cancel()
-        self.wakeActveMaxWorker?.cancel()
+        self.wakeActiveMaxWorker?.cancel()
         self.audioEngine.stop()
         self.audioEngine.inputNode.removeTap(onBus: 0)
         context.isActive = false
@@ -133,7 +133,7 @@ class AppleSpeechRecognizer: NSObject, SpeechRecognizerService {
                 }
                 if let r = result {
                     print("AppleSpeechRecognizer result " + r.bestTranscription.formattedString)
-                    strongSelf.wakeActveMaxWorker?.cancel()
+                    strongSelf.wakeActiveMaxWorker?.cancel()
                     let confidence = r.transcriptions.first?.segments.sorted(
                         by: { (a, b) -> Bool in
                             a.confidence <= b.confidence }).first?.confidence ?? 0.0

--- a/SpokeStack/AppleWakewordRecognizer.swift
+++ b/SpokeStack/AppleWakewordRecognizer.swift
@@ -71,6 +71,11 @@ public class AppleWakewordRecognizer: NSObject, WakewordRecognizerService {
         print("AppleWakewordRecognizer prepareAudioEngine")
         let buffer: Int = (self.configuration!.sampleRate / 1000) * self.configuration!.frameWidth
         let recordingFormat = self.audioEngine.inputNode.outputFormat(forBus: 0)
+        if let au = self.audioEngine.inputNode.audioUnit {
+            // fix for https://forums.developer.apple.com/thread/65656
+            AudioOutputUnitStop(au)
+            AudioUnitUninitialize(au)
+        }
         self.audioEngine.inputNode.removeTap(onBus: 0) // a belt-and-suspenders approach to fixing https://github.com/wenkesj/react-native-voice/issues/46
         self.audioEngine.inputNode.installTap(
             onBus: 0,

--- a/SpokeStack/AppleWakewordRecognizer.swift
+++ b/SpokeStack/AppleWakewordRecognizer.swift
@@ -71,11 +71,6 @@ public class AppleWakewordRecognizer: NSObject, WakewordRecognizerService {
         print("AppleWakewordRecognizer prepareAudioEngine")
         let buffer: Int = (self.configuration!.sampleRate / 1000) * self.configuration!.frameWidth
         let recordingFormat = self.audioEngine.inputNode.outputFormat(forBus: 0)
-        if let au = self.audioEngine.inputNode.audioUnit {
-            // fix for https://forums.developer.apple.com/thread/65656
-            AudioOutputUnitStop(au)
-            AudioUnitUninitialize(au)
-        }
         self.audioEngine.inputNode.removeTap(onBus: 0) // a belt-and-suspenders approach to fixing https://github.com/wenkesj/react-native-voice/issues/46
         self.audioEngine.inputNode.installTap(
             onBus: 0,

--- a/SpokeStack/AppleWakewordRecognizer.swift
+++ b/SpokeStack/AppleWakewordRecognizer.swift
@@ -97,7 +97,7 @@ public class AppleWakewordRecognizer: NSObject, WakewordRecognizerService {
                 self?.stopRecognition()
                 self?.startRecognition(context: context)
             }
-            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(self.configuration!.wakeActiveMax), execute: self.dispatchWorker!)
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(self.configuration!.wakewordRequestTimeout), execute: self.dispatchWorker!)
         } catch let error {
             self.delegate?.didError(error)
         }

--- a/SpokeStack/RecognizerConfiguration.swift
+++ b/SpokeStack/RecognizerConfiguration.swift
@@ -14,4 +14,5 @@ import Foundation
     public var languageLocale = "en-US"
     public var frameWidth: Int = 10
     @objc public var vadFallDelay: Int = 600
+    @objc public var wakeActiveMax: Int = 5000
 }

--- a/SpokeStack/SpeechRecognizer.swift
+++ b/SpokeStack/SpeechRecognizer.swift
@@ -17,4 +17,6 @@ import Foundation
     func deactivate() -> Void
     
     func didError(_ error: Error) -> Void
+    
+    func timedOut() -> Void
 }

--- a/SpokeStack/SpeechRecognizer.swift
+++ b/SpokeStack/SpeechRecognizer.swift
@@ -18,5 +18,5 @@ import Foundation
     
     func didError(_ error: Error) -> Void
     
-    func timedOut() -> Void
+    func timeout() -> Void
 }

--- a/SpokeStack/WakewordConfiguration.swift
+++ b/SpokeStack/WakewordConfiguration.swift
@@ -25,5 +25,5 @@ import Foundation
     public var sampleRate = 16000
     public var languageLocale = "en-US"
     public var frameWidth: Int = 10
-    public var wakeActiveMax: Int = 50000
+    public var wakewordRequestTimeout: Int = 50000
 }

--- a/SpokeStackFrameworkExample/AppleViewController.swift
+++ b/SpokeStackFrameworkExample/AppleViewController.swift
@@ -98,6 +98,10 @@ class AppleViewController: UIViewController {
 }
 
 extension AppleViewController: SpeechRecognizer, WakewordRecognizer {
+    func timedOut() {
+        print("timedOut")
+    }
+    
     func activate() {
         
     }

--- a/SpokeStackFrameworkExample/AppleViewController.swift
+++ b/SpokeStackFrameworkExample/AppleViewController.swift
@@ -98,8 +98,8 @@ class AppleViewController: UIViewController {
 }
 
 extension AppleViewController: SpeechRecognizer, WakewordRecognizer {
-    func timedOut() {
-        print("timedOut")
+    func timeout() {
+        print("timeout")
     }
     
     func activate() {

--- a/SpokeStackFrameworkExample/GoogleViewController.swift
+++ b/SpokeStackFrameworkExample/GoogleViewController.swift
@@ -99,8 +99,8 @@ class GoogleViewController: UIViewController {
 }
 
 extension GoogleViewController: SpeechRecognizer, WakewordRecognizer {
-    func timedOut() {
-        print("timedOut")
+    func timeout() {
+        print("timeout")
     }
     
     func activate() {

--- a/SpokeStackFrameworkExample/GoogleViewController.swift
+++ b/SpokeStackFrameworkExample/GoogleViewController.swift
@@ -99,6 +99,10 @@ class GoogleViewController: UIViewController {
 }
 
 extension GoogleViewController: SpeechRecognizer, WakewordRecognizer {
+    func timedOut() {
+        print("timedOut")
+    }
+    
     func activate() {
         
     }

--- a/SpokeStackFrameworkExample/WakeWordViewController.swift
+++ b/SpokeStackFrameworkExample/WakeWordViewController.swift
@@ -91,6 +91,10 @@ class WakeWordViewController: UIViewController {
 }
 
 extension WakeWordViewController: SpeechRecognizer, WakewordRecognizer {
+    func timedOut() {
+        print("timedOut")
+    }
+    
     func activate() {
         print("activate")
         self.pipeline.activate()

--- a/SpokeStackFrameworkExample/WakeWordViewController.swift
+++ b/SpokeStackFrameworkExample/WakeWordViewController.swift
@@ -91,8 +91,8 @@ class WakeWordViewController: UIViewController {
 }
 
 extension WakeWordViewController: SpeechRecognizer, WakewordRecognizer {
-    func timedOut() {
-        print("timedOut")
+    func timeout() {
+        print("timeout")
     }
     
     func activate() {


### PR DESCRIPTION
After discussing with @timmywil, there is a need for a new event that indicates that ASR, once activated, has not heard any speech and has timed out (by the `wakeActiveMax` time) before the pipeline transitions to the deactivated state. He was previously relying on an undocumented behavior in spokestack-android where the `close` function would raise `onRecognize` by side effect with an empty transcript. This behavior is not present in spokestack-ios, and so react-native-spokestack broke cross-platform compatibility. This pair of PRs (https://github.com/pylon/spokestack-android/pull/10) will allow both platforms to send the same explicit event upon `wakeActiveMax` length of silence.