### PR TITLE
Fix candidate for varying sample rates

### DIFF
--- a/SpokeStack/AppleSpeechRecognizer.swift
+++ b/SpokeStack/AppleSpeechRecognizer.swift
@@ -81,11 +81,15 @@ class AppleSpeechRecognizer: NSObject, SpeechRecognizerService {
         print("AppleSpeechRecognizer prepareAudioEngine")
         let buffer: Int = (self.configuration!.sampleRate / 1000) * self.configuration!.frameWidth
         let recordingFormat = self.audioEngine.inputNode.outputFormat(forBus: 0)
+        let inif = self.audioEngine.inputNode.inputFormat(forBus: 0)
+        let onof = self.audioEngine.outputNode.outputFormat(forBus: 0)
+        let onif = self.audioEngine.outputNode.inputFormat(forBus: 0)
+        print("AppleSpeechRecognizer prepareAudioEngine inof: " + recordingFormat.sampleRate.description + " inif: " + inif.sampleRate.description + " onof: " + onof.sampleRate.description + " onif: " + onif.sampleRate.description)
         self.audioEngine.inputNode.removeTap(onBus: 0) // a belt-and-suspenders approach to fixing https://github.com/wenkesj/react-native-voice/issues/46
         self.audioEngine.inputNode.installTap(
             onBus: 0,
             bufferSize: AVAudioFrameCount(buffer),
-            format: recordingFormat)
+            format: inif)
         {[weak self] buffer, when in
             guard let strongSelf = self else {
                 return

--- a/SpokeStack/AppleWakewordRecognizer.swift
+++ b/SpokeStack/AppleWakewordRecognizer.swift
@@ -71,11 +71,16 @@ public class AppleWakewordRecognizer: NSObject, WakewordRecognizerService {
         print("AppleWakewordRecognizer prepareAudioEngine")
         let buffer: Int = (self.configuration!.sampleRate / 1000) * self.configuration!.frameWidth
         let recordingFormat = self.audioEngine.inputNode.outputFormat(forBus: 0)
+        let recordingFormat = self.audioEngine.inputNode.outputFormat(forBus: 0)
+        let inif = self.audioEngine.inputNode.inputFormat(forBus: 0)
+        let onof = self.audioEngine.outputNode.outputFormat(forBus: 0)
+        let onif = self.audioEngine.outputNode.inputFormat(forBus: 0)
+        print("AppleWakewordRecognizer prepareAudioEngine inof: " + recordingFormat.sampleRate.description + " inif: " + inif.sampleRate.description + " onof: " + onof.sampleRate.description + " onif: " + onif.sampleRate.description)
         self.audioEngine.inputNode.removeTap(onBus: 0) // a belt-and-suspenders approach to fixing https://github.com/wenkesj/react-native-voice/issues/46
         self.audioEngine.inputNode.installTap(
             onBus: 0,
             bufferSize: AVAudioFrameCount(buffer),
-            format: recordingFormat)
+            format: inif)
         {[weak self] buffer, when in
             guard let strongSelf = self else {
                 return

--- a/SpokeStack/AudioController.swift
+++ b/SpokeStack/AudioController.swift
@@ -189,7 +189,9 @@ class AudioController {
     @discardableResult
     private func start() throws -> OSStatus {
         var status: OSStatus = noErr
-        status = AudioOutputUnitStart(remoteIOUnit!)
+        if let riou = remoteIOUnit {
+            status = AudioOutputUnitStart(riou)
+        }
         if status != noErr {
             throw AudioError.audioSessionSetup("AudioOutputUnitStart returned " + status.description)
         }


### PR DESCRIPTION
Based on testing, tapping the input node of the AudioEngine using the node's input format allows for varying sampling rates versus using the output format. Even if this doesn't completely cure the sample rate mismatch during tap, tracing will contain more helpful debugging information. Also, this contains a fix for an uncaught AudioController exception.