### PR TITLE
Ignore Apple error codes that indicate retries

### DIFF
--- a/SpokeStack/AppleSpeechRecognizer.swift
+++ b/SpokeStack/AppleSpeechRecognizer.swift
@@ -111,6 +111,8 @@ class AppleSpeechRecognizer: NSObject, SpeechRecognizerService {
                     if let nse: NSError = error as NSError? {
                         if nse.domain == "kAFAssistantErrorDomain" {
                             switch nse.code {
+                            case 0..<200: // Apple retry error: https://developer.nuance.com/public/Help/DragonMobileSDKReference_iOS/Error-codes.html
+                                break
                             case 203: // request timed out, retry
                                 print("AppleSpeechRecognizer createRecognitionTask resultHandler error 203")
                                 context.isActive = false
@@ -121,6 +123,8 @@ class AppleSpeechRecognizer: NSObject, SpeechRecognizerService {
                                 break
                             case 216: // Apple internal error: https://stackoverflow.com/questions/53037789/sfspeechrecognizer-216-error-with-multiple-requests?noredirect=1&lq=1)
                                 print("AppleSpeechRecognizer createRecognitionTask resultHandler error 216")
+                                break
+                            case 300..<603: // Apple retry error: https://developer.nuance.com/public/Help/DragonMobileSDKReference_iOS/Error-codes.html
                                 break
                             default:
                                 delegate.didError(e)

--- a/SpokeStack/AppleWakewordRecognizer.swift
+++ b/SpokeStack/AppleWakewordRecognizer.swift
@@ -128,6 +128,9 @@ public class AppleWakewordRecognizer: NSObject, WakewordRecognizerService {
                     if let nse: NSError = error as NSError? {
                         if nse.domain == "kAFAssistantErrorDomain" {
                             switch nse.code {
+                            case 0..<200: // Apple retry error: https://developer.nuance.com/public/Help/DragonMobileSDKReference_iOS/Error-codes.html
+                                print("AppleWakewordRecognizer createRecognitionTask resultHandler error " + nse.code.description)
+                                break
                             case 203: // request timed out, retry
                                 strongSelf.stopRecognition()
                                 strongSelf.startRecognition(context: context)
@@ -135,6 +138,9 @@ public class AppleWakewordRecognizer: NSObject, WakewordRecognizerService {
                             case 209: // ¯\_(ツ)_/¯
                                 break
                             case 216: // Apple internal error: https://stackoverflow.com/questions/53037789/sfspeechrecognizer-216-error-with-multiple-requests?noredirect=1&lq=1)
+                                break
+                            case 300..<603: // Apple retry error: https://developer.nuance.com/public/Help/DragonMobileSDKReference_iOS/Error-codes.html
+                                print("AppleWakewordRecognizer createRecognitionTask resultHandler error " + nse.code.description)
                                 break
                             default:
                                 delegate.didError(e)


### PR DESCRIPTION
Per https://developer.nuance.com/public/Help/DragonMobileSDKReference_iOS/Error-codes.html, there are swaths of `SFSpeechAudioBufferRecognitionRequest` errors that aren't errors, just indications to retry the recognition request. Since we don't store audio for a retry, there is nothing else to do if a request results in one of these errors. So we will simply ignore the error and keep going. Note that the lifespan of the request is not affected by these, so streaming will continue until control flow ends it.