### PR TITLE
take advantage of context to cut down on unecessary stop() calls

### DIFF
--- a/SpokeStack/SpeechPipeline.swift
+++ b/SpokeStack/SpeechPipeline.swift
@@ -95,8 +95,10 @@ import Foundation
     }
     
     @objc public func start() -> Void {
-        self.stop()
-        print("Apple SpeechPipeline start")
+        print("Apple SpeechPipeline start, context isActive " + self.context.isActive.description)
+        if (self.context.isActive) {
+            self.stop()
+        }
         AudioController.shared.startStreaming(context: self.context)
         self.wakewordRecognizerService.startStreaming(context: self.context)
         self.pipelineDelegate?.didStart()


### PR DESCRIPTION
This should prevent errors like that in the screenshot, which shouldn't ever happen according to Apple.

<img width="783" alt="Screen Shot 2019-03-28 at 4 56 42 PM" src="https://user-images.githubusercontent.com/119848/55264068-88a33b80-5249-11e9-8bd2-a0a5b347de87.png">

Additionally, this is a candidate for fixing the "com.apple.coreaudio.avfaudio error 10851" exception, whose cause still remains unknown.