### PR TITLE
Bubble up AudioController errors

### DIFF
--- a/SpokeStack/AudioController.swift
+++ b/SpokeStack/AudioController.swift
@@ -61,6 +61,7 @@ class AudioController {
     static let shared: AudioController = AudioController()
     
     weak var delegate: AudioControllerDelegate?
+    weak var pipelineDelegate: PipelineDelegate?
     
     var sampleRate: Int = 16000
     
@@ -103,11 +104,11 @@ class AudioController {
             try self.beginAudioSession()
             self.prepareRemoteIOUnit()
         } catch AudioError.audioSessionSetup(let message) {
-            self.delegate?.setupFailed(message)
+            self.pipelineDelegate?.setupFailed(message)
         } catch AudioError.general(let message) {
-            self.delegate?.setupFailed(message)
+            self.pipelineDelegate?.setupFailed(message)
         } catch {
-            self.delegate?.setupFailed("An unknown error occured setting the stream")
+            self.pipelineDelegate?.setupFailed("An unknown error occured setting the stream")
         }
     }
 
@@ -119,11 +120,11 @@ class AudioController {
             try self.start()
             try self.beginAudioSession()
         } catch AudioError.audioSessionSetup(let message) {
-            self.delegate?.setupFailed(message)
+            self.pipelineDelegate?.setupFailed(message)
         } catch AudioError.general(let message) {
-            self.delegate?.setupFailed(message)
+            self.pipelineDelegate?.setupFailed(message)
         } catch {
-            self.delegate?.setupFailed("An unknown error occured starting the stream")
+            self.pipelineDelegate?.setupFailed("An unknown error occured starting the stream")
         }
     }
 
@@ -133,9 +134,9 @@ class AudioController {
             try self.stop()
             try self.endAudioSession()
         } catch AudioError.audioSessionSetup(let message) {
-            self.delegate?.setupFailed(message)
+            self.pipelineDelegate?.setupFailed(message)
         } catch {
-            self.delegate?.setupFailed("An unknown error occured ending the stream")
+            self.pipelineDelegate?.setupFailed("An unknown error occured ending the stream")
         }
     }
 

--- a/SpokeStack/AudioControllerDelegate.swift
+++ b/SpokeStack/AudioControllerDelegate.swift
@@ -9,8 +9,6 @@
 import Foundation
 
 protocol AudioControllerDelegate: AnyObject {
-    
-    func setupFailed(_ error: String) -> Void
-    
+        
     func processSampleData(_ data: Data) -> Void
 }

--- a/SpokeStack/Error.swift
+++ b/SpokeStack/Error.swift
@@ -14,7 +14,7 @@ public enum AudioError: Error {
 }
 
 public enum SpeechPipelineError: Error {
-    case illegalState(message: String)
+    case illegalState(String)
 }
 
 public enum SpeechRecognizerError: Error {

--- a/SpokeStack/PipelineDelegate.swift
+++ b/SpokeStack/PipelineDelegate.swift
@@ -15,4 +15,6 @@ import Foundation
     func didStart() -> Void
 
     func didStop() -> Void
+    
+    func setupFailed(_ error: String) -> Void
 }

--- a/SpokeStack/SpeechPipeline.swift
+++ b/SpokeStack/SpeechPipeline.swift
@@ -60,6 +60,7 @@ import Foundation
         self.wakewordRecognizerService.delegate = self.wakewordDelegate
         
         self.pipelineDelegate = pipelineDelegate
+        AudioController.shared.pipelineDelegate = self.pipelineDelegate
         self.pipelineDelegate!.didInit()
     }
     
@@ -69,7 +70,7 @@ import Foundation
             let _ = self.wakewordDelegate,
             let _ = self.pipelineDelegate
         else {
-                return true
+            return true
         }
         return false
     }

--- a/SpokeStackFrameworkExample/AppleViewController.swift
+++ b/SpokeStackFrameworkExample/AppleViewController.swift
@@ -99,6 +99,10 @@ class AppleViewController: UIViewController {
 }
 
 extension AppleViewController: SpeechRecognizer, WakewordRecognizer, PipelineDelegate {
+    func setupFailed(_ error: String) {
+        print("setupFailed: " + error)
+    }
+    
     func didInit() {
         print("didInit")
     }

--- a/SpokeStackFrameworkExample/WakeWordViewController.swift
+++ b/SpokeStackFrameworkExample/WakeWordViewController.swift
@@ -128,5 +128,10 @@ extension WakeWordViewController: SpeechRecognizer, WakewordRecognizer, Pipeline
     func didStop() {
         print("didStop")
     }
+    
+    func setupFailed(_ error: String) {
+        print("audiocontroller setup failed: " + error)
+    }
+
 }
 


### PR DESCRIPTION
Turns out that during the course of refactoring the `AudioControllerDelegate` was not getting set. This meant that any errors during `AudioController` setup were being silently swallowed. Since the `SpeechPipeline` is solely in charge of initializing the `AudioController`, it makes sense to bubble up setup errors to `PipelineDelegate` instead of the `AudioControllerDelegate`, which is now just devoted to processing audio frames.