### PR TITLE
Avoid changing the AudioSession unless necessary

### DIFF
--- a/SpokeStack/AudioController.swift
+++ b/SpokeStack/AudioController.swift
@@ -150,12 +150,11 @@ class AudioController {
         let sessionCategory: AVAudioSession.Category = .playAndRecord
         let sessionOptions: AVAudioSession.CategoryOptions = [.duckOthers, .allowBluetoothA2DP, .allowAirPlay, .defaultToSpeaker]
         do {
-            if (!(session.category == sessionCategory) || !(session.categoryOptions == sessionOptions)) {
+            if ((session.category != sessionCategory) || !(session.categoryOptions.contains(sessionOptions))) { // TODO: add (session.ioBufferDuration != self.bufferDuration) once mode-based wakeword is enabled
+                print("AudioController beginAudioSession setting AudioSession")
                 try session.setActive(false, options: .notifyOthersOnDeactivation)
                 try session.setCategory(sessionCategory, mode: .default, options: sessionOptions)
-            }
-            try session.setPreferredIOBufferDuration(self.bufferDuration)
-            if !(session.isOtherAudioPlaying) {
+                try session.setPreferredIOBufferDuration(self.bufferDuration)
                 try session.setActive(true, options: .notifyOthersOnDeactivation)
             }
         } catch {


### PR DESCRIPTION
If the AudioSession is already in use by another library, the following error may be thrown in `beginAudioSession`:
https://www.osstatus.com/search/results?platform=all&framework=all&search=560030580
![IMG_1636](https://user-images.githubusercontent.com/119848/55663533-2b7d2c00-57ed-11e9-820c-4bf7973760cb.PNG)

In most cases though, the `AudioSession` does not need to be set if since it's not in use. For those cases, simply avoid doing so.