### PR TITLE
Example of input switching

### DIFF
--- a/SpokeStackFrameworkExample/Base.lproj/Main.storyboard
+++ b/SpokeStackFrameworkExample/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -27,9 +27,9 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ewK-ye-p0o">
-                                <rect key="frame" x="151" y="168" width="72" height="30"/>
+                                <rect key="frame" x="130" y="168" width="115" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Wakeword"/>
+                                <state key="normal" title="Apple Wakeword"/>
                                 <connections>
                                     <action selector="wakeWordAction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="PBl-wH-ng0"/>
                                 </connections>

--- a/SpokeStackFrameworkExample/WakeWordViewController.swift
+++ b/SpokeStackFrameworkExample/WakeWordViewController.swift
@@ -36,6 +36,18 @@ class WakeWordViewController: UIViewController {
         return button
     }()
     
+    var switchButton: UIButton = {
+        let button: UIButton = UIButton(frame: .zero)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitle("Switch Inputs", for: .normal)
+        button.addTarget(self,
+                         action: #selector(WakeWordViewController.switchInputs),
+                         for: .touchUpInside)
+        button.setTitleColor(.blue, for: .normal)
+        button.isEnabled = true
+        return button
+    }()
+    
     lazy public var pipeline: SpeechPipeline = {
         return try! SpeechPipeline(.appleSpeech,
                                    speechConfiguration: RecognizerConfiguration(),
@@ -62,6 +74,7 @@ class WakeWordViewController: UIViewController {
         
         self.view.addSubview(self.startRecordingButton)
         self.view.addSubview(self.stopRecordingButton)
+        self.view.addSubview(self.switchButton)
         
         self.startRecordingButton.centerYAnchor.constraint(equalTo: self.view.centerYAnchor).isActive = true
         self.startRecordingButton.leftAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leftAnchor).isActive = true
@@ -70,6 +83,10 @@ class WakeWordViewController: UIViewController {
         self.stopRecordingButton.topAnchor.constraint(equalTo: self.startRecordingButton.bottomAnchor, constant: 50.0).isActive = true
         self.stopRecordingButton.leftAnchor.constraint(equalTo: self.startRecordingButton.leftAnchor).isActive = true
         self.stopRecordingButton.rightAnchor.constraint(equalTo: self.startRecordingButton.rightAnchor).isActive = true
+        
+        self.switchButton.topAnchor.constraint(equalTo: self.startRecordingButton.bottomAnchor, constant: 100.0).isActive = true
+        self.switchButton.leftAnchor.constraint(equalTo: self.startRecordingButton.leftAnchor).isActive = true
+        self.switchButton.rightAnchor.constraint(equalTo: self.startRecordingButton.rightAnchor).isActive = true
     }
     
     @objc func startRecordingAction(_ sender: Any) {
@@ -84,6 +101,11 @@ class WakeWordViewController: UIViewController {
         self.pipeline.stop()
         self.stopRecordingButton.isEnabled.toggle()
         self.startRecordingButton.isEnabled.toggle()
+    }
+    
+    @objc func switchInputs() {
+        let appDelegate: AppDelegate? = UIApplication.shared.delegate as? AppDelegate
+        appDelegate?.switchInputsIfAvailable()  
     }
     
     @objc func dismissViewController(_ sender: Any?) -> Void {


### PR DESCRIPTION
Example app has a new "Switch inputs" button for switching between Bluetooth HFP input and default input. Note that the pipeline must be explicitly stopped and restarted when switching between inputs.