### PR TITLE
WebRTC VAD as CocoaPod dependency and not as git submodule/copy

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "SpokeStack/filter_audio"]
-	path = SpokeStack/filter_audio
-	url = git@github.com:pylon/filter_audio.git

--- a/Podfile
+++ b/Podfile
@@ -7,6 +7,7 @@ target 'SpokeStack' do
 
   # Pods for SpokeStack
   pod 'TensorFlowLiteSwift', '~> 1.14.0'
+  pod 'filter_audio', '~> 0.4.0', :modular_headers => true
 
   target 'SpokeStackTests' do
     inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,20 +1,24 @@
 PODS:
+  - filter_audio (0.4.0)
   - TensorFlowLiteC (1.14.0)
   - TensorFlowLiteSwift (1.14.0):
     - TensorFlowLiteC (= 1.14.0)
 
 DEPENDENCIES:
+  - filter_audio (~> 0.4.0)
   - TensorFlowLiteSwift (~> 1.14.0)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  trunk:
+    - filter_audio
     - TensorFlowLiteC
     - TensorFlowLiteSwift
 
 SPEC CHECKSUMS:
+  filter_audio: 4b63e257031d555b581e1bc7d063dd3f354ce7bc
   TensorFlowLiteC: a6702011fb661928634e59565b5fe262f69692d0
   TensorFlowLiteSwift: ac8c816ae2d65f631a96151e7991c46412aec7eb
 
-PODFILE CHECKSUM: 0f6a879620a048b1f9961ad5aa071a79c8489118
+PODFILE CHECKSUM: ecb119591575b7234b678f41f57fe6206bc448b8
 
-COCOAPODS: 1.6.1
+COCOAPODS: 1.8.0

--- a/SpokeStack.podspec
+++ b/SpokeStack.podspec
@@ -9,13 +9,14 @@ Pod::Spec.new do |s|
   s.license = {:type => 'Apache', :file => 'LICENSE'}
   s.ios.deployment_target = '11.0'
   s.swift_version = '4.2'
-  s.ios.framework = 'AVFoundation'
+  s.ios.framework = 'AVFoundation', 'CoreML'
   s.exclude_files = 'SpokeStackFrameworkExample/*.*', 'SpokeStackTests/*.*', 'SpokeStack/Info.plist'
-  s.source_files = 'SpokeStack/**/*.{swift,h,m,c}'
-  s.pod_target_xcconfig = {'SWIFT_INCLUDE_PATHS' => '${SRCROOT}/SpokeStack/VAD/filter_audio/** ${SRCROOT}/SpokeStack/VAD/Wit', 'HEADER_SEARCH_PATHS' => '${SRCROOT}/SpokeStack/VAD/filter_audio/** ${SRCROOT}/SpokeStack/VAD/Wit'}
+  s.source_files = 'SpokeStack/**/*.{swift,h,m,c,mlmodel}'
+  s.pod_target_xcconfig = {'SWIFT_INCLUDE_PATHS' => '$(SRCROOT)/SpokeStack/VAD/Wit', 'HEADER_SEARCH_PATHS' => '$(SRCROOT)/SpokeStack/VAD/Wit'}
   s.preserve_paths = 'SpokeStack/**/*.modulemap'
   s.public_header_files = 'SpokeStack/SpokeStack.h'
   s.dependency 'TensorFlowLiteSwift', '~> 1.14.0'
+  s.dependency 'filter_audio', '~> 0.3.1'
   s.static_framework = true
 
 end

--- a/SpokeStack.podspec
+++ b/SpokeStack.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.preserve_paths = 'SpokeStack/**/*.modulemap'
   s.public_header_files = 'SpokeStack/SpokeStack.h'
   s.dependency 'TensorFlowLiteSwift', '~> 1.14.0'
-  s.dependency 'filter_audio', '~> 0.3.1'
+  s.dependency 'filter_audio', '~> 0.4.0'
   s.static_framework = true
 
 end

--- a/SpokeStack.podspec
+++ b/SpokeStack.podspec
@@ -5,14 +5,14 @@ Pod::Spec.new do |s|
   s.summary = 'Spokestack provides an extensible speech recognition pipeline for the iOS platform.'
   s.homepage = 'https://www.pylon.com'
   s.authors = { 'Spokestack' => 'support@pylon.com' }
-  s.source = { :git => 'https://github.com/pylon/spokestack-ios.git', :tag => s.version.to_s, :submodules => true }
+  s.source = { :git => 'https://github.com/pylon/spokestack-ios.git', :tag => s.version.to_s }
   s.license = {:type => 'Apache', :file => 'LICENSE'}
   s.ios.deployment_target = '11.0'
   s.swift_version = '4.2'
   s.ios.framework = 'AVFoundation'
   s.exclude_files = 'SpokeStackFrameworkExample/*.*', 'SpokeStackTests/*.*', 'SpokeStack/Info.plist'
-  s.source_files = 'SpokeStack/**/*.{swift,h,m}'
-  s.pod_target_xcconfig = {'SWIFT_INCLUDE_PATHS' => '$(SRCROOT)/SpokeStack/filter_audio/** $(SRCROOT)/SpokeStack/VAD/Wit', 'HEADER_SEARCH_PATHS' => '$(SRCROOT)/SpokeStack/filter_audio/** $(SRCROOT)/SpokeStack/VAD/Wit'}
+  s.source_files = 'SpokeStack/**/*.{swift,h,m,c}'
+  s.pod_target_xcconfig = {'SWIFT_INCLUDE_PATHS' => '${SRCROOT}/SpokeStack/VAD/filter_audio/** ${SRCROOT}/SpokeStack/VAD/Wit', 'HEADER_SEARCH_PATHS' => '${SRCROOT}/SpokeStack/VAD/filter_audio/** ${SRCROOT}/SpokeStack/VAD/Wit'}
   s.preserve_paths = 'SpokeStack/**/*.modulemap'
   s.public_header_files = 'SpokeStack/SpokeStack.h'
   s.dependency 'TensorFlowLiteSwift', '~> 1.14.0'

--- a/SpokeStack.xcodeproj/project.pbxproj
+++ b/SpokeStack.xcodeproj/project.pbxproj
@@ -43,97 +43,7 @@
 		59A0D5C42204E799003709C3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 59A0D5C32204E799003709C3 /* Assets.xcassets */; };
 		59A0D5C72204E8E4003709C3 /* SpeechConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A0D5C52204E8E4003709C3 /* SpeechConfiguration.swift */; };
 		59A45E4F2243ED530089D023 /* PipelineDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A45E4E2243ED530089D023 /* PipelineDelegate.swift */; };
-		59BCF8E9234293D4008C5806 /* filter_audio.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF87F234293D4008C5806 /* filter_audio.h */; };
-		59BCF8EC234293D4008C5806 /* ns_core.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF884234293D4008C5806 /* ns_core.h */; };
-		59BCF8ED234293D4008C5806 /* nsx_core.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF885234293D4008C5806 /* nsx_core.c */; };
-		59BCF8EE234293D4008C5806 /* noise_suppression_x.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF886234293D4008C5806 /* noise_suppression_x.c */; };
-		59BCF8EF234293D4008C5806 /* noise_suppression.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF888234293D4008C5806 /* noise_suppression.h */; };
-		59BCF8F0234293D4008C5806 /* noise_suppression_x.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF889234293D4008C5806 /* noise_suppression_x.h */; };
-		59BCF8F1234293D4008C5806 /* nsx_core_c.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF88A234293D4008C5806 /* nsx_core_c.c */; };
-		59BCF8F2234293D4008C5806 /* defines.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF88B234293D4008C5806 /* defines.h */; };
-		59BCF8F3234293D4008C5806 /* ns_core.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF88C234293D4008C5806 /* ns_core.c */; };
-		59BCF8F4234293D4008C5806 /* nsx_core.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF88D234293D4008C5806 /* nsx_core.h */; };
-		59BCF8F5234293D4008C5806 /* windows_private.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF88E234293D4008C5806 /* windows_private.h */; };
-		59BCF8F6234293D4008C5806 /* noise_suppression.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF88F234293D4008C5806 /* noise_suppression.c */; };
-		59BCF8F7234293D4008C5806 /* nsx_defines.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF890234293D4008C5806 /* nsx_defines.h */; };
-		59BCF8F9234293D4008C5806 /* filteraudio.pc in Resources */ = {isa = PBXBuildFile; fileRef = 59BCF892234293D4008C5806 /* filteraudio.pc */; };
-		59BCF8FA234293D4008C5806 /* complex_fft_tables.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF894234293D4008C5806 /* complex_fft_tables.h */; };
-		59BCF8FB234293D4008C5806 /* complex_fft.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF895234293D4008C5806 /* complex_fft.c */; };
-		59BCF8FC234293D4008C5806 /* signal_processing_library.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF896234293D4008C5806 /* signal_processing_library.h */; };
-		59BCF8FD234293D4008C5806 /* stack_alloc.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF897234293D4008C5806 /* stack_alloc.h */; };
-		59BCF8FE234293D4008C5806 /* resample_by_2_internal.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF898234293D4008C5806 /* resample_by_2_internal.c */; };
-		59BCF8FF234293D4008C5806 /* speex_resampler.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF899234293D4008C5806 /* speex_resampler.h */; };
-		59BCF900234293D4008C5806 /* energy.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF89A234293D4008C5806 /* energy.c */; };
-		59BCF901234293D4008C5806 /* downsample_fast.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF89B234293D4008C5806 /* downsample_fast.c */; };
-		59BCF902234293D4008C5806 /* splitting_filter.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF89C234293D4008C5806 /* splitting_filter.c */; };
-		59BCF903234293D4008C5806 /* spl_init.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF89D234293D4008C5806 /* spl_init.c */; };
-		59BCF904234293D4008C5806 /* fft4g.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF89E234293D4008C5806 /* fft4g.c */; };
-		59BCF905234293D4008C5806 /* delay_estimator_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF89F234293D4008C5806 /* delay_estimator_internal.h */; };
-		59BCF906234293D4008C5806 /* cross_correlation.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8A0234293D4008C5806 /* cross_correlation.c */; };
-		59BCF907234293D4008C5806 /* ring_buffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8A1234293D4008C5806 /* ring_buffer.h */; };
-		59BCF908234293D4008C5806 /* real_fft.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8A2234293D4008C5806 /* real_fft.h */; };
-		59BCF909234293D4008C5806 /* division_operations.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8A3234293D4008C5806 /* division_operations.c */; };
-		59BCF90A234293D4008C5806 /* get_scaling_square.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8A4234293D4008C5806 /* get_scaling_square.c */; };
-		59BCF90B234293D4008C5806 /* spl_inl.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8A5234293D4008C5806 /* spl_inl.h */; };
-		59BCF90C234293D4008C5806 /* spl_sqrt_floor.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8A6234293D4008C5806 /* spl_sqrt_floor.c */; };
-		59BCF90D234293D4008C5806 /* delay_estimator_wrapper.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8A7234293D4008C5806 /* delay_estimator_wrapper.c */; };
-		59BCF90E234293D4008C5806 /* delay_estimator.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8A8234293D4008C5806 /* delay_estimator.c */; };
-		59BCF90F234293D4008C5806 /* high_pass_filter.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8A9234293D4008C5806 /* high_pass_filter.c */; };
-		59BCF910234293D4008C5806 /* speex_resampler.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8AA234293D4008C5806 /* speex_resampler.c */; };
-		59BCF911234293D4008C5806 /* resample_by_2_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8AB234293D4008C5806 /* resample_by_2_internal.h */; };
-		59BCF912234293D4008C5806 /* min_max_operations.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8AC234293D4008C5806 /* min_max_operations.c */; };
-		59BCF913234293D4008C5806 /* fft4g.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8AD234293D4008C5806 /* fft4g.h */; };
-		59BCF914234293D4008C5806 /* vector_scaling_operations.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8AE234293D4008C5806 /* vector_scaling_operations.c */; };
-		59BCF915234293D4008C5806 /* resample_fractional.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8AF234293D4008C5806 /* resample_fractional.c */; };
-		59BCF916234293D4008C5806 /* real_fft.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8B0234293D4008C5806 /* real_fft.c */; };
-		59BCF917234293D4008C5806 /* complex_bit_reverse.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8B1234293D4008C5806 /* complex_bit_reverse.c */; };
-		59BCF918234293D4008C5806 /* ring_buffer.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8B2234293D4008C5806 /* ring_buffer.c */; };
-		59BCF919234293D4008C5806 /* randomization_functions.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8B3234293D4008C5806 /* randomization_functions.c */; };
-		59BCF91A234293D4008C5806 /* dot_product_with_scale.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8B4234293D4008C5806 /* dot_product_with_scale.c */; };
-		59BCF91B234293D4008C5806 /* float_util.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8B5234293D4008C5806 /* float_util.c */; };
-		59BCF91C234293D4008C5806 /* delay_estimator.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8B6234293D4008C5806 /* delay_estimator.h */; };
-		59BCF91D234293D4008C5806 /* delay_estimator_wrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8B7234293D4008C5806 /* delay_estimator_wrapper.h */; };
-		59BCF91E234293D4008C5806 /* copy_set_operations.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8B8234293D4008C5806 /* copy_set_operations.c */; };
-		59BCF91F234293D4008C5806 /* resample_by_2.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8B9234293D4008C5806 /* resample_by_2.c */; };
-		59BCF920234293D4008C5806 /* resample_sse.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8BA234293D4008C5806 /* resample_sse.h */; };
-		59BCF921234293D4008C5806 /* resample_48khz.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8BB234293D4008C5806 /* resample_48khz.c */; };
-		59BCF922234293D4008C5806 /* arch.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8BC234293D4008C5806 /* arch.h */; };
-		59BCF923234293D4008C5806 /* spl_sqrt.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8BD234293D4008C5806 /* spl_sqrt.c */; };
-		59BCF924234293D4008C5806 /* aec_core_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8BF234293D4008C5806 /* aec_core_sse2.c */; };
-		59BCF925234293D4008C5806 /* aec_core.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8C0234293D4008C5806 /* aec_core.c */; };
-		59BCF926234293D4008C5806 /* echo_cancellation_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8C1234293D4008C5806 /* echo_cancellation_internal.h */; };
-		59BCF927234293D4008C5806 /* aec_rdft.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8C2234293D4008C5806 /* aec_rdft.h */; };
-		59BCF928234293D4008C5806 /* echo_cancellation.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8C4234293D4008C5806 /* echo_cancellation.h */; };
-		59BCF929234293D4008C5806 /* aec_resampler.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8C5234293D4008C5806 /* aec_resampler.h */; };
-		59BCF92A234293D4008C5806 /* aec_core_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8C6234293D4008C5806 /* aec_core_internal.h */; };
-		59BCF92B234293D4008C5806 /* aec_rdft_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8C7234293D4008C5806 /* aec_rdft_sse2.c */; };
-		59BCF92C234293D4008C5806 /* aec_core.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8C8234293D4008C5806 /* aec_core.h */; };
-		59BCF92D234293D4008C5806 /* aec_rdft.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8C9234293D4008C5806 /* aec_rdft.c */; };
-		59BCF92E234293D4008C5806 /* aec_resampler.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8CA234293D4008C5806 /* aec_resampler.c */; };
-		59BCF92F234293D4008C5806 /* echo_cancellation.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8CB234293D4008C5806 /* echo_cancellation.c */; };
-		59BCF930234293D4008C5806 /* aec_common.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8CC234293D4008C5806 /* aec_common.h */; };
-		59BCF931234293D4008C5806 /* filters.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8CE234293D4008C5806 /* filters.c */; };
-		59BCF932234293D4008C5806 /* filters.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8CF234293D4008C5806 /* filters.h */; };
-		59BCF933234293D4008C5806 /* README in Resources */ = {isa = PBXBuildFile; fileRef = 59BCF8D0234293D4008C5806 /* README */; };
-		59BCF934234293D4008C5806 /* gain_control.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8D3234293D4008C5806 /* gain_control.h */; };
-		59BCF935234293D4008C5806 /* analog_agc.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8D4234293D4008C5806 /* analog_agc.h */; };
-		59BCF936234293D4008C5806 /* digital_agc.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8D5234293D4008C5806 /* digital_agc.h */; };
-		59BCF937234293D4008C5806 /* analog_agc.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8D6234293D4008C5806 /* analog_agc.c */; };
-		59BCF938234293D4008C5806 /* digital_agc.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8D7234293D4008C5806 /* digital_agc.c */; };
-		59BCF939234293D4008C5806 /* filter_audio.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8D8234293D4008C5806 /* filter_audio.c */; };
-		59BCF93A234293D4008C5806 /* vad_sp.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8DB234293D4008C5806 /* vad_sp.c */; };
-		59BCF93B234293D4008C5806 /* webrtc_vad.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8DC234293D4008C5806 /* webrtc_vad.c */; };
-		59BCF93C234293D4008C5806 /* vad_core.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8DD234293D4008C5806 /* vad_core.h */; };
-		59BCF93D234293D4008C5806 /* vad.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8DF234293D4008C5806 /* vad.h */; };
-		59BCF93E234293D4008C5806 /* webrtc_vad.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8E0234293D4008C5806 /* webrtc_vad.h */; };
-		59BCF93F234293D4008C5806 /* mock_vad.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8E2234293D4008C5806 /* mock_vad.h */; };
-		59BCF940234293D4008C5806 /* vad_gmm.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8E3234293D4008C5806 /* vad_gmm.h */; };
-		59BCF941234293D4008C5806 /* vad_filterbank.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8E4234293D4008C5806 /* vad_filterbank.c */; };
-		59BCF942234293D4008C5806 /* vad_core.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8E5234293D4008C5806 /* vad_core.c */; };
-		59BCF943234293D4008C5806 /* vad_sp.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8E6234293D4008C5806 /* vad_sp.h */; };
-		59BCF944234293D4008C5806 /* vad_filterbank.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8E7234293D4008C5806 /* vad_filterbank.h */; };
-		59BCF945234293D4008C5806 /* vad_gmm.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8E8234293D4008C5806 /* vad_gmm.c */; };
-		59BCF947234293EE008C5806 /* WebRTCVAD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF946234293EE008C5806 /* WebRTCVAD.swift */; };
+		59C15D53234D322A00B091F4 /* WebRTCVAD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C15D52234D322A00B091F4 /* WebRTCVAD.swift */; };
 		59C2AFDA2319CB7100E47AC5 /* RingBufferTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C2AFD92319CB7100E47AC5 /* RingBufferTest.swift */; };
 		59C2AFDB2319CE5800E47AC5 /* SpeechConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A0D5C52204E8E4003709C3 /* SpeechConfiguration.swift */; };
 		59C2AFDC2319CE6200E47AC5 /* SpeechProcessors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5936594D220A1A7A00C0365F /* SpeechProcessors.swift */; };
@@ -248,98 +158,7 @@
 		59A0D5C32204E799003709C3 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		59A0D5C52204E8E4003709C3 /* SpeechConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpeechConfiguration.swift; sourceTree = "<group>"; };
 		59A45E4E2243ED530089D023 /* PipelineDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PipelineDelegate.swift; sourceTree = "<group>"; };
-		59BCF87F234293D4008C5806 /* filter_audio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = filter_audio.h; sourceTree = "<group>"; };
-		59BCF884234293D4008C5806 /* ns_core.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ns_core.h; sourceTree = "<group>"; };
-		59BCF885234293D4008C5806 /* nsx_core.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = nsx_core.c; sourceTree = "<group>"; };
-		59BCF886234293D4008C5806 /* noise_suppression_x.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = noise_suppression_x.c; sourceTree = "<group>"; };
-		59BCF888234293D4008C5806 /* noise_suppression.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = noise_suppression.h; sourceTree = "<group>"; };
-		59BCF889234293D4008C5806 /* noise_suppression_x.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = noise_suppression_x.h; sourceTree = "<group>"; };
-		59BCF88A234293D4008C5806 /* nsx_core_c.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = nsx_core_c.c; sourceTree = "<group>"; };
-		59BCF88B234293D4008C5806 /* defines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = defines.h; sourceTree = "<group>"; };
-		59BCF88C234293D4008C5806 /* ns_core.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ns_core.c; sourceTree = "<group>"; };
-		59BCF88D234293D4008C5806 /* nsx_core.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = nsx_core.h; sourceTree = "<group>"; };
-		59BCF88E234293D4008C5806 /* windows_private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = windows_private.h; sourceTree = "<group>"; };
-		59BCF88F234293D4008C5806 /* noise_suppression.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = noise_suppression.c; sourceTree = "<group>"; };
-		59BCF890234293D4008C5806 /* nsx_defines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = nsx_defines.h; sourceTree = "<group>"; };
-		59BCF892234293D4008C5806 /* filteraudio.pc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = filteraudio.pc; sourceTree = "<group>"; };
-		59BCF894234293D4008C5806 /* complex_fft_tables.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = complex_fft_tables.h; sourceTree = "<group>"; };
-		59BCF895234293D4008C5806 /* complex_fft.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = complex_fft.c; sourceTree = "<group>"; };
-		59BCF896234293D4008C5806 /* signal_processing_library.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = signal_processing_library.h; sourceTree = "<group>"; };
-		59BCF897234293D4008C5806 /* stack_alloc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stack_alloc.h; sourceTree = "<group>"; };
-		59BCF898234293D4008C5806 /* resample_by_2_internal.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = resample_by_2_internal.c; sourceTree = "<group>"; };
-		59BCF899234293D4008C5806 /* speex_resampler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = speex_resampler.h; sourceTree = "<group>"; };
-		59BCF89A234293D4008C5806 /* energy.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = energy.c; sourceTree = "<group>"; };
-		59BCF89B234293D4008C5806 /* downsample_fast.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = downsample_fast.c; sourceTree = "<group>"; };
-		59BCF89C234293D4008C5806 /* splitting_filter.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = splitting_filter.c; sourceTree = "<group>"; };
-		59BCF89D234293D4008C5806 /* spl_init.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = spl_init.c; sourceTree = "<group>"; };
-		59BCF89E234293D4008C5806 /* fft4g.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = fft4g.c; sourceTree = "<group>"; };
-		59BCF89F234293D4008C5806 /* delay_estimator_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = delay_estimator_internal.h; sourceTree = "<group>"; };
-		59BCF8A0234293D4008C5806 /* cross_correlation.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cross_correlation.c; sourceTree = "<group>"; };
-		59BCF8A1234293D4008C5806 /* ring_buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ring_buffer.h; sourceTree = "<group>"; };
-		59BCF8A2234293D4008C5806 /* real_fft.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = real_fft.h; sourceTree = "<group>"; };
-		59BCF8A3234293D4008C5806 /* division_operations.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = division_operations.c; sourceTree = "<group>"; };
-		59BCF8A4234293D4008C5806 /* get_scaling_square.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = get_scaling_square.c; sourceTree = "<group>"; };
-		59BCF8A5234293D4008C5806 /* spl_inl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spl_inl.h; sourceTree = "<group>"; };
-		59BCF8A6234293D4008C5806 /* spl_sqrt_floor.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = spl_sqrt_floor.c; sourceTree = "<group>"; };
-		59BCF8A7234293D4008C5806 /* delay_estimator_wrapper.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = delay_estimator_wrapper.c; sourceTree = "<group>"; };
-		59BCF8A8234293D4008C5806 /* delay_estimator.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = delay_estimator.c; sourceTree = "<group>"; };
-		59BCF8A9234293D4008C5806 /* high_pass_filter.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = high_pass_filter.c; sourceTree = "<group>"; };
-		59BCF8AA234293D4008C5806 /* speex_resampler.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = speex_resampler.c; sourceTree = "<group>"; };
-		59BCF8AB234293D4008C5806 /* resample_by_2_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = resample_by_2_internal.h; sourceTree = "<group>"; };
-		59BCF8AC234293D4008C5806 /* min_max_operations.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = min_max_operations.c; sourceTree = "<group>"; };
-		59BCF8AD234293D4008C5806 /* fft4g.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fft4g.h; sourceTree = "<group>"; };
-		59BCF8AE234293D4008C5806 /* vector_scaling_operations.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vector_scaling_operations.c; sourceTree = "<group>"; };
-		59BCF8AF234293D4008C5806 /* resample_fractional.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = resample_fractional.c; sourceTree = "<group>"; };
-		59BCF8B0234293D4008C5806 /* real_fft.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = real_fft.c; sourceTree = "<group>"; };
-		59BCF8B1234293D4008C5806 /* complex_bit_reverse.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = complex_bit_reverse.c; sourceTree = "<group>"; };
-		59BCF8B2234293D4008C5806 /* ring_buffer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ring_buffer.c; sourceTree = "<group>"; };
-		59BCF8B3234293D4008C5806 /* randomization_functions.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = randomization_functions.c; sourceTree = "<group>"; };
-		59BCF8B4234293D4008C5806 /* dot_product_with_scale.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dot_product_with_scale.c; sourceTree = "<group>"; };
-		59BCF8B5234293D4008C5806 /* float_util.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = float_util.c; sourceTree = "<group>"; };
-		59BCF8B6234293D4008C5806 /* delay_estimator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = delay_estimator.h; sourceTree = "<group>"; };
-		59BCF8B7234293D4008C5806 /* delay_estimator_wrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = delay_estimator_wrapper.h; sourceTree = "<group>"; };
-		59BCF8B8234293D4008C5806 /* copy_set_operations.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = copy_set_operations.c; sourceTree = "<group>"; };
-		59BCF8B9234293D4008C5806 /* resample_by_2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = resample_by_2.c; sourceTree = "<group>"; };
-		59BCF8BA234293D4008C5806 /* resample_sse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = resample_sse.h; sourceTree = "<group>"; };
-		59BCF8BB234293D4008C5806 /* resample_48khz.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = resample_48khz.c; sourceTree = "<group>"; };
-		59BCF8BC234293D4008C5806 /* arch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = arch.h; sourceTree = "<group>"; };
-		59BCF8BD234293D4008C5806 /* spl_sqrt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = spl_sqrt.c; sourceTree = "<group>"; };
-		59BCF8BF234293D4008C5806 /* aec_core_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = aec_core_sse2.c; sourceTree = "<group>"; };
-		59BCF8C0234293D4008C5806 /* aec_core.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = aec_core.c; sourceTree = "<group>"; };
-		59BCF8C1234293D4008C5806 /* echo_cancellation_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = echo_cancellation_internal.h; sourceTree = "<group>"; };
-		59BCF8C2234293D4008C5806 /* aec_rdft.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aec_rdft.h; sourceTree = "<group>"; };
-		59BCF8C4234293D4008C5806 /* echo_cancellation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = echo_cancellation.h; sourceTree = "<group>"; };
-		59BCF8C5234293D4008C5806 /* aec_resampler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aec_resampler.h; sourceTree = "<group>"; };
-		59BCF8C6234293D4008C5806 /* aec_core_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aec_core_internal.h; sourceTree = "<group>"; };
-		59BCF8C7234293D4008C5806 /* aec_rdft_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = aec_rdft_sse2.c; sourceTree = "<group>"; };
-		59BCF8C8234293D4008C5806 /* aec_core.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aec_core.h; sourceTree = "<group>"; };
-		59BCF8C9234293D4008C5806 /* aec_rdft.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = aec_rdft.c; sourceTree = "<group>"; };
-		59BCF8CA234293D4008C5806 /* aec_resampler.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = aec_resampler.c; sourceTree = "<group>"; };
-		59BCF8CB234293D4008C5806 /* echo_cancellation.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = echo_cancellation.c; sourceTree = "<group>"; };
-		59BCF8CC234293D4008C5806 /* aec_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aec_common.h; sourceTree = "<group>"; };
-		59BCF8CE234293D4008C5806 /* filters.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = filters.c; sourceTree = "<group>"; };
-		59BCF8CF234293D4008C5806 /* filters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = filters.h; sourceTree = "<group>"; };
-		59BCF8D0234293D4008C5806 /* README */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README; sourceTree = "<group>"; };
-		59BCF8D3234293D4008C5806 /* gain_control.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gain_control.h; sourceTree = "<group>"; };
-		59BCF8D4234293D4008C5806 /* analog_agc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = analog_agc.h; sourceTree = "<group>"; };
-		59BCF8D5234293D4008C5806 /* digital_agc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = digital_agc.h; sourceTree = "<group>"; };
-		59BCF8D6234293D4008C5806 /* analog_agc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = analog_agc.c; sourceTree = "<group>"; };
-		59BCF8D7234293D4008C5806 /* digital_agc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = digital_agc.c; sourceTree = "<group>"; };
-		59BCF8D8234293D4008C5806 /* filter_audio.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = filter_audio.c; sourceTree = "<group>"; };
-		59BCF8D9234293D4008C5806 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
-		59BCF8DB234293D4008C5806 /* vad_sp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vad_sp.c; sourceTree = "<group>"; };
-		59BCF8DC234293D4008C5806 /* webrtc_vad.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = webrtc_vad.c; sourceTree = "<group>"; };
-		59BCF8DD234293D4008C5806 /* vad_core.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vad_core.h; sourceTree = "<group>"; };
-		59BCF8DF234293D4008C5806 /* vad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vad.h; sourceTree = "<group>"; };
-		59BCF8E0234293D4008C5806 /* webrtc_vad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = webrtc_vad.h; sourceTree = "<group>"; };
-		59BCF8E2234293D4008C5806 /* mock_vad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mock_vad.h; sourceTree = "<group>"; };
-		59BCF8E3234293D4008C5806 /* vad_gmm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vad_gmm.h; sourceTree = "<group>"; };
-		59BCF8E4234293D4008C5806 /* vad_filterbank.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vad_filterbank.c; sourceTree = "<group>"; };
-		59BCF8E5234293D4008C5806 /* vad_core.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vad_core.c; sourceTree = "<group>"; };
-		59BCF8E6234293D4008C5806 /* vad_sp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vad_sp.h; sourceTree = "<group>"; };
-		59BCF8E7234293D4008C5806 /* vad_filterbank.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vad_filterbank.h; sourceTree = "<group>"; };
-		59BCF8E8234293D4008C5806 /* vad_gmm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vad_gmm.c; sourceTree = "<group>"; };
-		59BCF946234293EE008C5806 /* WebRTCVAD.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WebRTCVAD.swift; path = SpokeStack/WebRTCVAD.swift; sourceTree = SOURCE_ROOT; };
+		59C15D52234D322A00B091F4 /* WebRTCVAD.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WebRTCVAD.swift; path = SpokeStack/WebRTCVAD.swift; sourceTree = SOURCE_ROOT; };
 		59C2AFD92319CB7100E47AC5 /* RingBufferTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RingBufferTest.swift; sourceTree = "<group>"; };
 		59C2AFED231ED07100E47AC5 /* WebRTCVADTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebRTCVADTest.swift; sourceTree = "<group>"; };
 		59D78F5E2322D13700728A98 /* AudioControllerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioControllerTest.swift; sourceTree = "<group>"; };
@@ -562,7 +381,7 @@
 		59062EFD22A5AA6C00613AD8 /* VAD */ = {
 			isa = PBXGroup;
 			children = (
-				59BCF87E234293D4008C5806 /* filter_audio */,
+				59C15D51234D321A00B091F4 /* filter_audio */,
 				593757AA22D68A9500AA7516 /* Wit */,
 			);
 			path = VAD;
@@ -591,191 +410,12 @@
 			path = Wit;
 			sourceTree = "<group>";
 		};
-		59BCF87E234293D4008C5806 /* filter_audio */ = {
+		59C15D51234D321A00B091F4 /* filter_audio */ = {
 			isa = PBXGroup;
 			children = (
-				59BCF946234293EE008C5806 /* WebRTCVAD.swift */,
-				59BCF87F234293D4008C5806 /* filter_audio.h */,
-				59BCF883234293D4008C5806 /* ns */,
-				59BCF892234293D4008C5806 /* filteraudio.pc */,
-				59BCF893234293D4008C5806 /* other */,
-				59BCF8BE234293D4008C5806 /* aec */,
-				59BCF8CD234293D4008C5806 /* zam */,
-				59BCF8D0234293D4008C5806 /* README */,
-				59BCF8D1234293D4008C5806 /* agc */,
-				59BCF8D8234293D4008C5806 /* filter_audio.c */,
-				59BCF8D9234293D4008C5806 /* module.modulemap */,
-				59BCF8DA234293D4008C5806 /* vad */,
+				59C15D52234D322A00B091F4 /* WebRTCVAD.swift */,
 			);
-			path = filter_audio;
-			sourceTree = "<group>";
-		};
-		59BCF883234293D4008C5806 /* ns */ = {
-			isa = PBXGroup;
-			children = (
-				59BCF884234293D4008C5806 /* ns_core.h */,
-				59BCF885234293D4008C5806 /* nsx_core.c */,
-				59BCF886234293D4008C5806 /* noise_suppression_x.c */,
-				59BCF887234293D4008C5806 /* include */,
-				59BCF88A234293D4008C5806 /* nsx_core_c.c */,
-				59BCF88B234293D4008C5806 /* defines.h */,
-				59BCF88C234293D4008C5806 /* ns_core.c */,
-				59BCF88D234293D4008C5806 /* nsx_core.h */,
-				59BCF88E234293D4008C5806 /* windows_private.h */,
-				59BCF88F234293D4008C5806 /* noise_suppression.c */,
-				59BCF890234293D4008C5806 /* nsx_defines.h */,
-			);
-			path = ns;
-			sourceTree = "<group>";
-		};
-		59BCF887234293D4008C5806 /* include */ = {
-			isa = PBXGroup;
-			children = (
-				59BCF888234293D4008C5806 /* noise_suppression.h */,
-				59BCF889234293D4008C5806 /* noise_suppression_x.h */,
-			);
-			path = include;
-			sourceTree = "<group>";
-		};
-		59BCF893234293D4008C5806 /* other */ = {
-			isa = PBXGroup;
-			children = (
-				59BCF894234293D4008C5806 /* complex_fft_tables.h */,
-				59BCF895234293D4008C5806 /* complex_fft.c */,
-				59BCF896234293D4008C5806 /* signal_processing_library.h */,
-				59BCF897234293D4008C5806 /* stack_alloc.h */,
-				59BCF898234293D4008C5806 /* resample_by_2_internal.c */,
-				59BCF899234293D4008C5806 /* speex_resampler.h */,
-				59BCF89A234293D4008C5806 /* energy.c */,
-				59BCF89B234293D4008C5806 /* downsample_fast.c */,
-				59BCF89C234293D4008C5806 /* splitting_filter.c */,
-				59BCF89D234293D4008C5806 /* spl_init.c */,
-				59BCF89E234293D4008C5806 /* fft4g.c */,
-				59BCF89F234293D4008C5806 /* delay_estimator_internal.h */,
-				59BCF8A0234293D4008C5806 /* cross_correlation.c */,
-				59BCF8A1234293D4008C5806 /* ring_buffer.h */,
-				59BCF8A2234293D4008C5806 /* real_fft.h */,
-				59BCF8A3234293D4008C5806 /* division_operations.c */,
-				59BCF8A4234293D4008C5806 /* get_scaling_square.c */,
-				59BCF8A5234293D4008C5806 /* spl_inl.h */,
-				59BCF8A6234293D4008C5806 /* spl_sqrt_floor.c */,
-				59BCF8A7234293D4008C5806 /* delay_estimator_wrapper.c */,
-				59BCF8A8234293D4008C5806 /* delay_estimator.c */,
-				59BCF8A9234293D4008C5806 /* high_pass_filter.c */,
-				59BCF8AA234293D4008C5806 /* speex_resampler.c */,
-				59BCF8AB234293D4008C5806 /* resample_by_2_internal.h */,
-				59BCF8AC234293D4008C5806 /* min_max_operations.c */,
-				59BCF8AD234293D4008C5806 /* fft4g.h */,
-				59BCF8AE234293D4008C5806 /* vector_scaling_operations.c */,
-				59BCF8AF234293D4008C5806 /* resample_fractional.c */,
-				59BCF8B0234293D4008C5806 /* real_fft.c */,
-				59BCF8B1234293D4008C5806 /* complex_bit_reverse.c */,
-				59BCF8B2234293D4008C5806 /* ring_buffer.c */,
-				59BCF8B3234293D4008C5806 /* randomization_functions.c */,
-				59BCF8B4234293D4008C5806 /* dot_product_with_scale.c */,
-				59BCF8B5234293D4008C5806 /* float_util.c */,
-				59BCF8B6234293D4008C5806 /* delay_estimator.h */,
-				59BCF8B7234293D4008C5806 /* delay_estimator_wrapper.h */,
-				59BCF8B8234293D4008C5806 /* copy_set_operations.c */,
-				59BCF8B9234293D4008C5806 /* resample_by_2.c */,
-				59BCF8BA234293D4008C5806 /* resample_sse.h */,
-				59BCF8BB234293D4008C5806 /* resample_48khz.c */,
-				59BCF8BC234293D4008C5806 /* arch.h */,
-				59BCF8BD234293D4008C5806 /* spl_sqrt.c */,
-			);
-			path = other;
-			sourceTree = "<group>";
-		};
-		59BCF8BE234293D4008C5806 /* aec */ = {
-			isa = PBXGroup;
-			children = (
-				59BCF8BF234293D4008C5806 /* aec_core_sse2.c */,
-				59BCF8C0234293D4008C5806 /* aec_core.c */,
-				59BCF8C1234293D4008C5806 /* echo_cancellation_internal.h */,
-				59BCF8C2234293D4008C5806 /* aec_rdft.h */,
-				59BCF8C3234293D4008C5806 /* include */,
-				59BCF8C5234293D4008C5806 /* aec_resampler.h */,
-				59BCF8C6234293D4008C5806 /* aec_core_internal.h */,
-				59BCF8C7234293D4008C5806 /* aec_rdft_sse2.c */,
-				59BCF8C8234293D4008C5806 /* aec_core.h */,
-				59BCF8C9234293D4008C5806 /* aec_rdft.c */,
-				59BCF8CA234293D4008C5806 /* aec_resampler.c */,
-				59BCF8CB234293D4008C5806 /* echo_cancellation.c */,
-				59BCF8CC234293D4008C5806 /* aec_common.h */,
-			);
-			path = aec;
-			sourceTree = "<group>";
-		};
-		59BCF8C3234293D4008C5806 /* include */ = {
-			isa = PBXGroup;
-			children = (
-				59BCF8C4234293D4008C5806 /* echo_cancellation.h */,
-			);
-			path = include;
-			sourceTree = "<group>";
-		};
-		59BCF8CD234293D4008C5806 /* zam */ = {
-			isa = PBXGroup;
-			children = (
-				59BCF8CE234293D4008C5806 /* filters.c */,
-				59BCF8CF234293D4008C5806 /* filters.h */,
-			);
-			path = zam;
-			sourceTree = "<group>";
-		};
-		59BCF8D1234293D4008C5806 /* agc */ = {
-			isa = PBXGroup;
-			children = (
-				59BCF8D2234293D4008C5806 /* include */,
-				59BCF8D4234293D4008C5806 /* analog_agc.h */,
-				59BCF8D5234293D4008C5806 /* digital_agc.h */,
-				59BCF8D6234293D4008C5806 /* analog_agc.c */,
-				59BCF8D7234293D4008C5806 /* digital_agc.c */,
-			);
-			path = agc;
-			sourceTree = "<group>";
-		};
-		59BCF8D2234293D4008C5806 /* include */ = {
-			isa = PBXGroup;
-			children = (
-				59BCF8D3234293D4008C5806 /* gain_control.h */,
-			);
-			path = include;
-			sourceTree = "<group>";
-		};
-		59BCF8DA234293D4008C5806 /* vad */ = {
-			isa = PBXGroup;
-			children = (
-				59BCF8DB234293D4008C5806 /* vad_sp.c */,
-				59BCF8DC234293D4008C5806 /* webrtc_vad.c */,
-				59BCF8DD234293D4008C5806 /* vad_core.h */,
-				59BCF8DE234293D4008C5806 /* include */,
-				59BCF8E1234293D4008C5806 /* mock */,
-				59BCF8E3234293D4008C5806 /* vad_gmm.h */,
-				59BCF8E4234293D4008C5806 /* vad_filterbank.c */,
-				59BCF8E5234293D4008C5806 /* vad_core.c */,
-				59BCF8E6234293D4008C5806 /* vad_sp.h */,
-				59BCF8E7234293D4008C5806 /* vad_filterbank.h */,
-				59BCF8E8234293D4008C5806 /* vad_gmm.c */,
-			);
-			path = vad;
-			sourceTree = "<group>";
-		};
-		59BCF8DE234293D4008C5806 /* include */ = {
-			isa = PBXGroup;
-			children = (
-				59BCF8DF234293D4008C5806 /* vad.h */,
-				59BCF8E0234293D4008C5806 /* webrtc_vad.h */,
-			);
-			path = include;
-			sourceTree = "<group>";
-		};
-		59BCF8E1234293D4008C5806 /* mock */ = {
-			isa = PBXGroup;
-			children = (
-				59BCF8E2234293D4008C5806 /* mock_vad.h */,
-			);
-			path = mock;
+			name = filter_audio;
 			sourceTree = "<group>";
 		};
 		59FB0C8922AEE4DA00FB9662 /* Extensions */ = {
@@ -815,47 +455,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				59BCF8EC234293D4008C5806 /* ns_core.h in Headers */,
-				59BCF936234293D4008C5806 /* digital_agc.h in Headers */,
-				59BCF926234293D4008C5806 /* echo_cancellation_internal.h in Headers */,
-				59BCF928234293D4008C5806 /* echo_cancellation.h in Headers */,
-				59BCF93C234293D4008C5806 /* vad_core.h in Headers */,
-				59BCF934234293D4008C5806 /* gain_control.h in Headers */,
-				59BCF8F2234293D4008C5806 /* defines.h in Headers */,
-				59BCF93E234293D4008C5806 /* webrtc_vad.h in Headers */,
-				59BCF8F0234293D4008C5806 /* noise_suppression_x.h in Headers */,
-				59BCF908234293D4008C5806 /* real_fft.h in Headers */,
-				59BCF940234293D4008C5806 /* vad_gmm.h in Headers */,
-				59BCF943234293D4008C5806 /* vad_sp.h in Headers */,
-				59BCF93F234293D4008C5806 /* mock_vad.h in Headers */,
-				59BCF8FA234293D4008C5806 /* complex_fft_tables.h in Headers */,
-				59BCF90B234293D4008C5806 /* spl_inl.h in Headers */,
-				59BCF913234293D4008C5806 /* fft4g.h in Headers */,
-				59BCF8EF234293D4008C5806 /* noise_suppression.h in Headers */,
-				59BCF927234293D4008C5806 /* aec_rdft.h in Headers */,
-				59BCF8F5234293D4008C5806 /* windows_private.h in Headers */,
-				59BCF905234293D4008C5806 /* delay_estimator_internal.h in Headers */,
-				59BCF935234293D4008C5806 /* analog_agc.h in Headers */,
-				59BCF907234293D4008C5806 /* ring_buffer.h in Headers */,
-				59BCF92A234293D4008C5806 /* aec_core_internal.h in Headers */,
-				59BCF8FF234293D4008C5806 /* speex_resampler.h in Headers */,
-				59BCF8F7234293D4008C5806 /* nsx_defines.h in Headers */,
-				59BCF8FC234293D4008C5806 /* signal_processing_library.h in Headers */,
-				59BCF929234293D4008C5806 /* aec_resampler.h in Headers */,
 				01D31F4C216BAF260055FD45 /* SpokeStack.h in Headers */,
-				59BCF911234293D4008C5806 /* resample_by_2_internal.h in Headers */,
-				59BCF8E9234293D4008C5806 /* filter_audio.h in Headers */,
-				59BCF92C234293D4008C5806 /* aec_core.h in Headers */,
-				59BCF91D234293D4008C5806 /* delay_estimator_wrapper.h in Headers */,
-				59BCF91C234293D4008C5806 /* delay_estimator.h in Headers */,
-				59BCF932234293D4008C5806 /* filters.h in Headers */,
-				59BCF944234293D4008C5806 /* vad_filterbank.h in Headers */,
-				59BCF93D234293D4008C5806 /* vad.h in Headers */,
-				59BCF930234293D4008C5806 /* aec_common.h in Headers */,
-				59BCF8F4234293D4008C5806 /* nsx_core.h in Headers */,
-				59BCF8FD234293D4008C5806 /* stack_alloc.h in Headers */,
-				59BCF920234293D4008C5806 /* resample_sse.h in Headers */,
-				59BCF922234293D4008C5806 /* arch.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -986,8 +586,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				59BCF933234293D4008C5806 /* README in Resources */,
-				59BCF8F9234293D4008C5806 /* filteraudio.pc in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1087,80 +685,32 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				59BCF931234293D4008C5806 /* filters.c in Sources */,
-				59BCF937234293D4008C5806 /* analog_agc.c in Sources */,
-				59BCF90E234293D4008C5806 /* delay_estimator.c in Sources */,
-				59BCF919234293D4008C5806 /* randomization_functions.c in Sources */,
-				59BCF92E234293D4008C5806 /* aec_resampler.c in Sources */,
 				59365948220889EE00C0365F /* AppleWakewordRecognizer.swift in Sources */,
-				59BCF916234293D4008C5806 /* real_fft.c in Sources */,
 				59FB0C8822A98E1900FB9662 /* CoreMLWakewordRecognizer.swift in Sources */,
 				01D31F6F216BAFD90055FD45 /* SpeechContext.swift in Sources */,
-				59BCF90C234293D4008C5806 /* spl_sqrt_floor.c in Sources */,
-				59BCF8F3234293D4008C5806 /* ns_core.c in Sources */,
 				59E0E1372301F0A80060F012 /* Trace.swift in Sources */,
-				59BCF91E234293D4008C5806 /* copy_set_operations.c in Sources */,
-				59BCF8F1234293D4008C5806 /* nsx_core_c.c in Sources */,
-				59BCF938234293D4008C5806 /* digital_agc.c in Sources */,
-				59BCF900234293D4008C5806 /* energy.c in Sources */,
-				59BCF925234293D4008C5806 /* aec_core.c in Sources */,
-				59BCF93A234293D4008C5806 /* vad_sp.c in Sources */,
-				59BCF906234293D4008C5806 /* cross_correlation.c in Sources */,
 				59E0E13522FE2C2B0060F012 /* SignalProcessing.swift in Sources */,
-				59BCF93B234293D4008C5806 /* webrtc_vad.c in Sources */,
 				59A0D5C72204E8E4003709C3 /* SpeechConfiguration.swift in Sources */,
-				59BCF942234293D4008C5806 /* vad_core.c in Sources */,
 				59FB0C8D22B0640700FB9662 /* RingBuffer.swift in Sources */,
-				59BCF947234293EE008C5806 /* WebRTCVAD.swift in Sources */,
-				59BCF92B234293D4008C5806 /* aec_rdft_sse2.c in Sources */,
-				59BCF921234293D4008C5806 /* resample_48khz.c in Sources */,
-				59BCF902234293D4008C5806 /* splitting_filter.c in Sources */,
 				01D31F8E216BB0370055FD45 /* Typealiases.swift in Sources */,
 				01D31F66216BAFB50055FD45 /* Error.swift in Sources */,
 				01D31F6A216BAFC60055FD45 /* SpeechPipeline.swift in Sources */,
-				59BCF8FE234293D4008C5806 /* resample_by_2_internal.c in Sources */,
-				59BCF90A234293D4008C5806 /* get_scaling_square.c in Sources */,
 				5937579322D5281900AA7516 /* VADDelegate.swift in Sources */,
-				59BCF909234293D4008C5806 /* division_operations.c in Sources */,
-				59BCF910234293D4008C5806 /* speex_resampler.c in Sources */,
 				5967108E21F7AE6B00CBFC88 /* AppleSpeechRecognizer.swift in Sources */,
-				59BCF92D234293D4008C5806 /* aec_rdft.c in Sources */,
 				5936594C2209EA1800C0365F /* SpeechProcessor.swift in Sources */,
-				59BCF914234293D4008C5806 /* vector_scaling_operations.c in Sources */,
 				594154B822F8AD2200E3624E /* TFLiteWakewordRecognizer.swift in Sources */,
 				59FB0C8B22AEE4F100FB9662 /* Data+Extensions.swift in Sources */,
 				59FB0C9322B17A9A00FB9662 /* WakeWordFilter.mlmodel in Sources */,
-				59BCF924234293D4008C5806 /* aec_core_sse2.c in Sources */,
-				59BCF918234293D4008C5806 /* ring_buffer.c in Sources */,
-				59BCF945234293D4008C5806 /* vad_gmm.c in Sources */,
 				59A45E4F2243ED530089D023 /* PipelineDelegate.swift in Sources */,
-				59BCF91F234293D4008C5806 /* resample_by_2.c in Sources */,
-				59BCF939234293D4008C5806 /* filter_audio.c in Sources */,
-				59BCF912234293D4008C5806 /* min_max_operations.c in Sources */,
-				59BCF923234293D4008C5806 /* spl_sqrt.c in Sources */,
-				59BCF915234293D4008C5806 /* resample_fractional.c in Sources */,
 				01D31F62216BAFA40055FD45 /* AudioController.swift in Sources */,
-				59BCF901234293D4008C5806 /* downsample_fast.c in Sources */,
-				59BCF8FB234293D4008C5806 /* complex_fft.c in Sources */,
-				59BCF91A234293D4008C5806 /* dot_product_with_scale.c in Sources */,
-				59BCF90D234293D4008C5806 /* delay_estimator_wrapper.c in Sources */,
 				5936594E220A1A7A00C0365F /* SpeechProcessors.swift in Sources */,
-				59BCF941234293D4008C5806 /* vad_filterbank.c in Sources */,
-				59BCF903234293D4008C5806 /* spl_init.c in Sources */,
-				59BCF8EE234293D4008C5806 /* noise_suppression_x.c in Sources */,
 				01D31F8A216BB0220055FD45 /* Results.swift in Sources */,
 				5936594A2209DDBA00C0365F /* SpeechEventListener.swift in Sources */,
-				59BCF8F6234293D4008C5806 /* noise_suppression.c in Sources */,
 				59FB0C9522B17AA300FB9662 /* WakeWordDetect.mlmodel in Sources */,
 				59FB0C8522A5C48B00FB9662 /* WITVad.m in Sources */,
-				59BCF917234293D4008C5806 /* complex_bit_reverse.c in Sources */,
 				01D31F79216BAFEF0055FD45 /* AudioControllerDelegate.swift in Sources */,
+				59C15D53234D322A00B091F4 /* WebRTCVAD.swift in Sources */,
 				59FB0C8322A5C48400FB9662 /* WITCvad.m in Sources */,
-				59BCF8ED234293D4008C5806 /* nsx_core.c in Sources */,
-				59BCF92F234293D4008C5806 /* echo_cancellation.c in Sources */,
-				59BCF91B234293D4008C5806 /* float_util.c in Sources */,
-				59BCF904234293D4008C5806 /* fft4g.c in Sources */,
-				59BCF90F234293D4008C5806 /* high_pass_filter.c in Sources */,
 				59FB0C8F22B0682900FB9662 /* FFT.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SpokeStack.xcodeproj/project.pbxproj
+++ b/SpokeStack.xcodeproj/project.pbxproj
@@ -36,32 +36,6 @@
 		5936594C2209EA1800C0365F /* SpeechProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5936594B2209EA1800C0365F /* SpeechProcessor.swift */; };
 		5936594E220A1A7A00C0365F /* SpeechProcessors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5936594D220A1A7A00C0365F /* SpeechProcessors.swift */; };
 		5937579322D5281900AA7516 /* VADDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5937579222D5281900AA7516 /* VADDelegate.swift */; };
-		593B1D5722C50A0E004D938E /* complex_fft.c in Sources */ = {isa = PBXBuildFile; fileRef = 593B1D5322C50A0E004D938E /* complex_fft.c */; };
-		593B1D5822C50A0E004D938E /* complex_bit_reverse.c in Sources */ = {isa = PBXBuildFile; fileRef = 593B1D5422C50A0E004D938E /* complex_bit_reverse.c */; };
-		593B1D5A22C50A0E004D938E /* copy_set_operations.c in Sources */ = {isa = PBXBuildFile; fileRef = 593B1D5622C50A0E004D938E /* copy_set_operations.c */; };
-		593B1D6922C50A95004D938E /* real_fft.c in Sources */ = {isa = PBXBuildFile; fileRef = 593B1D5B22C50A93004D938E /* real_fft.c */; };
-		593B1D6A22C50A95004D938E /* vector_scaling_operations.c in Sources */ = {isa = PBXBuildFile; fileRef = 593B1D5C22C50A93004D938E /* vector_scaling_operations.c */; };
-		593B1D6B22C50A95004D938E /* spl_sqrt.c in Sources */ = {isa = PBXBuildFile; fileRef = 593B1D5D22C50A93004D938E /* spl_sqrt.c */; };
-		593B1D6C22C50A95004D938E /* resample_by_2.c in Sources */ = {isa = PBXBuildFile; fileRef = 593B1D5E22C50A93004D938E /* resample_by_2.c */; };
-		593B1D6D22C50A95004D938E /* resample_fractional.c in Sources */ = {isa = PBXBuildFile; fileRef = 593B1D5F22C50A94004D938E /* resample_fractional.c */; };
-		593B1D6E22C50A95004D938E /* resample_by_2_internal.c in Sources */ = {isa = PBXBuildFile; fileRef = 593B1D6022C50A94004D938E /* resample_by_2_internal.c */; };
-		593B1D6F22C50A95004D938E /* dot_product_with_scale.c in Sources */ = {isa = PBXBuildFile; fileRef = 593B1D6122C50A94004D938E /* dot_product_with_scale.c */; };
-		593B1D7022C50A95004D938E /* get_scaling_square.c in Sources */ = {isa = PBXBuildFile; fileRef = 593B1D6222C50A94004D938E /* get_scaling_square.c */; };
-		593B1D7122C50A95004D938E /* spl_init.c in Sources */ = {isa = PBXBuildFile; fileRef = 593B1D6322C50A94004D938E /* spl_init.c */; };
-		593B1D7222C50A95004D938E /* division_operations.c in Sources */ = {isa = PBXBuildFile; fileRef = 593B1D6422C50A94004D938E /* division_operations.c */; };
-		593B1D7322C50A95004D938E /* resample_48khz.c in Sources */ = {isa = PBXBuildFile; fileRef = 593B1D6522C50A94004D938E /* resample_48khz.c */; };
-		593B1D7422C50A95004D938E /* downsample_fast.c in Sources */ = {isa = PBXBuildFile; fileRef = 593B1D6622C50A95004D938E /* downsample_fast.c */; };
-		593B1D7522C50A95004D938E /* energy.c in Sources */ = {isa = PBXBuildFile; fileRef = 593B1D6722C50A95004D938E /* energy.c */; };
-		593B1D7622C50A95004D938E /* min_max_operations.c in Sources */ = {isa = PBXBuildFile; fileRef = 593B1D6822C50A95004D938E /* min_max_operations.c */; };
-		593B1D7922C50AB4004D938E /* analog_agc.c in Sources */ = {isa = PBXBuildFile; fileRef = 593B1D7722C50AB4004D938E /* analog_agc.c */; };
-		593B1D7A22C50AB4004D938E /* digital_agc.c in Sources */ = {isa = PBXBuildFile; fileRef = 593B1D7822C50AB4004D938E /* digital_agc.c */; };
-		593B1D8122C50AF3004D938E /* vad_filterbank.c in Sources */ = {isa = PBXBuildFile; fileRef = 593B1D7B22C50AF2004D938E /* vad_filterbank.c */; };
-		593B1D8322C50AF3004D938E /* vad_gmm.c in Sources */ = {isa = PBXBuildFile; fileRef = 593B1D7D22C50AF2004D938E /* vad_gmm.c */; };
-		593B1D8422C50AF3004D938E /* vad_sp.c in Sources */ = {isa = PBXBuildFile; fileRef = 593B1D7E22C50AF2004D938E /* vad_sp.c */; };
-		593B1D8522C50AF3004D938E /* vad_core.c in Sources */ = {isa = PBXBuildFile; fileRef = 593B1D7F22C50AF2004D938E /* vad_core.c */; };
-		593B1D8622C50AF3004D938E /* webrtc_vad.c in Sources */ = {isa = PBXBuildFile; fileRef = 593B1D8022C50AF3004D938E /* webrtc_vad.c */; };
-		593B1D8822C5401D004D938E /* cross_correlation.c in Sources */ = {isa = PBXBuildFile; fileRef = 593B1D8722C5401C004D938E /* cross_correlation.c */; };
-		593B1D8C22CA9243004D938E /* WebRTCVAD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 593B1D8B22CA9243004D938E /* WebRTCVAD.swift */; };
 		594154B822F8AD2200E3624E /* TFLiteWakewordRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594154B722F8AD2200E3624E /* TFLiteWakewordRecognizer.swift */; };
 		5967108E21F7AE6B00CBFC88 /* AppleSpeechRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5967108D21F7AE6B00CBFC88 /* AppleSpeechRecognizer.swift */; };
 		59A0D5C02204E786003709C3 /* AppleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A0D5BD2204E786003709C3 /* AppleViewController.swift */; };
@@ -69,6 +43,97 @@
 		59A0D5C42204E799003709C3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 59A0D5C32204E799003709C3 /* Assets.xcassets */; };
 		59A0D5C72204E8E4003709C3 /* SpeechConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A0D5C52204E8E4003709C3 /* SpeechConfiguration.swift */; };
 		59A45E4F2243ED530089D023 /* PipelineDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A45E4E2243ED530089D023 /* PipelineDelegate.swift */; };
+		59BCF8E9234293D4008C5806 /* filter_audio.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF87F234293D4008C5806 /* filter_audio.h */; };
+		59BCF8EC234293D4008C5806 /* ns_core.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF884234293D4008C5806 /* ns_core.h */; };
+		59BCF8ED234293D4008C5806 /* nsx_core.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF885234293D4008C5806 /* nsx_core.c */; };
+		59BCF8EE234293D4008C5806 /* noise_suppression_x.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF886234293D4008C5806 /* noise_suppression_x.c */; };
+		59BCF8EF234293D4008C5806 /* noise_suppression.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF888234293D4008C5806 /* noise_suppression.h */; };
+		59BCF8F0234293D4008C5806 /* noise_suppression_x.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF889234293D4008C5806 /* noise_suppression_x.h */; };
+		59BCF8F1234293D4008C5806 /* nsx_core_c.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF88A234293D4008C5806 /* nsx_core_c.c */; };
+		59BCF8F2234293D4008C5806 /* defines.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF88B234293D4008C5806 /* defines.h */; };
+		59BCF8F3234293D4008C5806 /* ns_core.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF88C234293D4008C5806 /* ns_core.c */; };
+		59BCF8F4234293D4008C5806 /* nsx_core.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF88D234293D4008C5806 /* nsx_core.h */; };
+		59BCF8F5234293D4008C5806 /* windows_private.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF88E234293D4008C5806 /* windows_private.h */; };
+		59BCF8F6234293D4008C5806 /* noise_suppression.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF88F234293D4008C5806 /* noise_suppression.c */; };
+		59BCF8F7234293D4008C5806 /* nsx_defines.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF890234293D4008C5806 /* nsx_defines.h */; };
+		59BCF8F9234293D4008C5806 /* filteraudio.pc in Resources */ = {isa = PBXBuildFile; fileRef = 59BCF892234293D4008C5806 /* filteraudio.pc */; };
+		59BCF8FA234293D4008C5806 /* complex_fft_tables.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF894234293D4008C5806 /* complex_fft_tables.h */; };
+		59BCF8FB234293D4008C5806 /* complex_fft.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF895234293D4008C5806 /* complex_fft.c */; };
+		59BCF8FC234293D4008C5806 /* signal_processing_library.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF896234293D4008C5806 /* signal_processing_library.h */; };
+		59BCF8FD234293D4008C5806 /* stack_alloc.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF897234293D4008C5806 /* stack_alloc.h */; };
+		59BCF8FE234293D4008C5806 /* resample_by_2_internal.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF898234293D4008C5806 /* resample_by_2_internal.c */; };
+		59BCF8FF234293D4008C5806 /* speex_resampler.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF899234293D4008C5806 /* speex_resampler.h */; };
+		59BCF900234293D4008C5806 /* energy.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF89A234293D4008C5806 /* energy.c */; };
+		59BCF901234293D4008C5806 /* downsample_fast.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF89B234293D4008C5806 /* downsample_fast.c */; };
+		59BCF902234293D4008C5806 /* splitting_filter.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF89C234293D4008C5806 /* splitting_filter.c */; };
+		59BCF903234293D4008C5806 /* spl_init.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF89D234293D4008C5806 /* spl_init.c */; };
+		59BCF904234293D4008C5806 /* fft4g.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF89E234293D4008C5806 /* fft4g.c */; };
+		59BCF905234293D4008C5806 /* delay_estimator_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF89F234293D4008C5806 /* delay_estimator_internal.h */; };
+		59BCF906234293D4008C5806 /* cross_correlation.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8A0234293D4008C5806 /* cross_correlation.c */; };
+		59BCF907234293D4008C5806 /* ring_buffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8A1234293D4008C5806 /* ring_buffer.h */; };
+		59BCF908234293D4008C5806 /* real_fft.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8A2234293D4008C5806 /* real_fft.h */; };
+		59BCF909234293D4008C5806 /* division_operations.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8A3234293D4008C5806 /* division_operations.c */; };
+		59BCF90A234293D4008C5806 /* get_scaling_square.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8A4234293D4008C5806 /* get_scaling_square.c */; };
+		59BCF90B234293D4008C5806 /* spl_inl.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8A5234293D4008C5806 /* spl_inl.h */; };
+		59BCF90C234293D4008C5806 /* spl_sqrt_floor.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8A6234293D4008C5806 /* spl_sqrt_floor.c */; };
+		59BCF90D234293D4008C5806 /* delay_estimator_wrapper.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8A7234293D4008C5806 /* delay_estimator_wrapper.c */; };
+		59BCF90E234293D4008C5806 /* delay_estimator.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8A8234293D4008C5806 /* delay_estimator.c */; };
+		59BCF90F234293D4008C5806 /* high_pass_filter.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8A9234293D4008C5806 /* high_pass_filter.c */; };
+		59BCF910234293D4008C5806 /* speex_resampler.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8AA234293D4008C5806 /* speex_resampler.c */; };
+		59BCF911234293D4008C5806 /* resample_by_2_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8AB234293D4008C5806 /* resample_by_2_internal.h */; };
+		59BCF912234293D4008C5806 /* min_max_operations.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8AC234293D4008C5806 /* min_max_operations.c */; };
+		59BCF913234293D4008C5806 /* fft4g.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8AD234293D4008C5806 /* fft4g.h */; };
+		59BCF914234293D4008C5806 /* vector_scaling_operations.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8AE234293D4008C5806 /* vector_scaling_operations.c */; };
+		59BCF915234293D4008C5806 /* resample_fractional.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8AF234293D4008C5806 /* resample_fractional.c */; };
+		59BCF916234293D4008C5806 /* real_fft.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8B0234293D4008C5806 /* real_fft.c */; };
+		59BCF917234293D4008C5806 /* complex_bit_reverse.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8B1234293D4008C5806 /* complex_bit_reverse.c */; };
+		59BCF918234293D4008C5806 /* ring_buffer.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8B2234293D4008C5806 /* ring_buffer.c */; };
+		59BCF919234293D4008C5806 /* randomization_functions.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8B3234293D4008C5806 /* randomization_functions.c */; };
+		59BCF91A234293D4008C5806 /* dot_product_with_scale.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8B4234293D4008C5806 /* dot_product_with_scale.c */; };
+		59BCF91B234293D4008C5806 /* float_util.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8B5234293D4008C5806 /* float_util.c */; };
+		59BCF91C234293D4008C5806 /* delay_estimator.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8B6234293D4008C5806 /* delay_estimator.h */; };
+		59BCF91D234293D4008C5806 /* delay_estimator_wrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8B7234293D4008C5806 /* delay_estimator_wrapper.h */; };
+		59BCF91E234293D4008C5806 /* copy_set_operations.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8B8234293D4008C5806 /* copy_set_operations.c */; };
+		59BCF91F234293D4008C5806 /* resample_by_2.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8B9234293D4008C5806 /* resample_by_2.c */; };
+		59BCF920234293D4008C5806 /* resample_sse.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8BA234293D4008C5806 /* resample_sse.h */; };
+		59BCF921234293D4008C5806 /* resample_48khz.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8BB234293D4008C5806 /* resample_48khz.c */; };
+		59BCF922234293D4008C5806 /* arch.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8BC234293D4008C5806 /* arch.h */; };
+		59BCF923234293D4008C5806 /* spl_sqrt.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8BD234293D4008C5806 /* spl_sqrt.c */; };
+		59BCF924234293D4008C5806 /* aec_core_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8BF234293D4008C5806 /* aec_core_sse2.c */; };
+		59BCF925234293D4008C5806 /* aec_core.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8C0234293D4008C5806 /* aec_core.c */; };
+		59BCF926234293D4008C5806 /* echo_cancellation_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8C1234293D4008C5806 /* echo_cancellation_internal.h */; };
+		59BCF927234293D4008C5806 /* aec_rdft.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8C2234293D4008C5806 /* aec_rdft.h */; };
+		59BCF928234293D4008C5806 /* echo_cancellation.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8C4234293D4008C5806 /* echo_cancellation.h */; };
+		59BCF929234293D4008C5806 /* aec_resampler.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8C5234293D4008C5806 /* aec_resampler.h */; };
+		59BCF92A234293D4008C5806 /* aec_core_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8C6234293D4008C5806 /* aec_core_internal.h */; };
+		59BCF92B234293D4008C5806 /* aec_rdft_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8C7234293D4008C5806 /* aec_rdft_sse2.c */; };
+		59BCF92C234293D4008C5806 /* aec_core.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8C8234293D4008C5806 /* aec_core.h */; };
+		59BCF92D234293D4008C5806 /* aec_rdft.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8C9234293D4008C5806 /* aec_rdft.c */; };
+		59BCF92E234293D4008C5806 /* aec_resampler.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8CA234293D4008C5806 /* aec_resampler.c */; };
+		59BCF92F234293D4008C5806 /* echo_cancellation.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8CB234293D4008C5806 /* echo_cancellation.c */; };
+		59BCF930234293D4008C5806 /* aec_common.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8CC234293D4008C5806 /* aec_common.h */; };
+		59BCF931234293D4008C5806 /* filters.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8CE234293D4008C5806 /* filters.c */; };
+		59BCF932234293D4008C5806 /* filters.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8CF234293D4008C5806 /* filters.h */; };
+		59BCF933234293D4008C5806 /* README in Resources */ = {isa = PBXBuildFile; fileRef = 59BCF8D0234293D4008C5806 /* README */; };
+		59BCF934234293D4008C5806 /* gain_control.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8D3234293D4008C5806 /* gain_control.h */; };
+		59BCF935234293D4008C5806 /* analog_agc.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8D4234293D4008C5806 /* analog_agc.h */; };
+		59BCF936234293D4008C5806 /* digital_agc.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8D5234293D4008C5806 /* digital_agc.h */; };
+		59BCF937234293D4008C5806 /* analog_agc.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8D6234293D4008C5806 /* analog_agc.c */; };
+		59BCF938234293D4008C5806 /* digital_agc.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8D7234293D4008C5806 /* digital_agc.c */; };
+		59BCF939234293D4008C5806 /* filter_audio.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8D8234293D4008C5806 /* filter_audio.c */; };
+		59BCF93A234293D4008C5806 /* vad_sp.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8DB234293D4008C5806 /* vad_sp.c */; };
+		59BCF93B234293D4008C5806 /* webrtc_vad.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8DC234293D4008C5806 /* webrtc_vad.c */; };
+		59BCF93C234293D4008C5806 /* vad_core.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8DD234293D4008C5806 /* vad_core.h */; };
+		59BCF93D234293D4008C5806 /* vad.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8DF234293D4008C5806 /* vad.h */; };
+		59BCF93E234293D4008C5806 /* webrtc_vad.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8E0234293D4008C5806 /* webrtc_vad.h */; };
+		59BCF93F234293D4008C5806 /* mock_vad.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8E2234293D4008C5806 /* mock_vad.h */; };
+		59BCF940234293D4008C5806 /* vad_gmm.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8E3234293D4008C5806 /* vad_gmm.h */; };
+		59BCF941234293D4008C5806 /* vad_filterbank.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8E4234293D4008C5806 /* vad_filterbank.c */; };
+		59BCF942234293D4008C5806 /* vad_core.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8E5234293D4008C5806 /* vad_core.c */; };
+		59BCF943234293D4008C5806 /* vad_sp.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8E6234293D4008C5806 /* vad_sp.h */; };
+		59BCF944234293D4008C5806 /* vad_filterbank.h in Headers */ = {isa = PBXBuildFile; fileRef = 59BCF8E7234293D4008C5806 /* vad_filterbank.h */; };
+		59BCF945234293D4008C5806 /* vad_gmm.c in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF8E8234293D4008C5806 /* vad_gmm.c */; };
+		59BCF947234293EE008C5806 /* WebRTCVAD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59BCF946234293EE008C5806 /* WebRTCVAD.swift */; };
 		59C2AFDA2319CB7100E47AC5 /* RingBufferTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C2AFD92319CB7100E47AC5 /* RingBufferTest.swift */; };
 		59C2AFDB2319CE5800E47AC5 /* SpeechConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A0D5C52204E8E4003709C3 /* SpeechConfiguration.swift */; };
 		59C2AFDC2319CE6200E47AC5 /* SpeechProcessors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5936594D220A1A7A00C0365F /* SpeechProcessors.swift */; };
@@ -78,7 +143,6 @@
 		59C2AFE02319CEA100E47AC5 /* AppleWakewordRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59365947220889EE00C0365F /* AppleWakewordRecognizer.swift */; };
 		59C2AFE12319CEA800E47AC5 /* CoreMLWakewordRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FB0C8722A98E1900FB9662 /* CoreMLWakewordRecognizer.swift */; };
 		59C2AFE22319CEAE00E47AC5 /* TFLiteWakewordRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594154B722F8AD2200E3624E /* TFLiteWakewordRecognizer.swift */; };
-		59C2AFE32319CEBC00E47AC5 /* WebRTCVAD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 593B1D8B22CA9243004D938E /* WebRTCVAD.swift */; };
 		59C2AFE42319CEC300E47AC5 /* Trace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E0E1362301F0A80060F012 /* Trace.swift */; };
 		59C2AFE52319CED100E47AC5 /* AppleSpeechRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5967108D21F7AE6B00CBFC88 /* AppleSpeechRecognizer.swift */; };
 		59C2AFE62319CEEF00E47AC5 /* RingBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FB0C8C22B0640700FB9662 /* RingBuffer.swift */; };
@@ -177,35 +241,6 @@
 		5936594B2209EA1800C0365F /* SpeechProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechProcessor.swift; sourceTree = "<group>"; };
 		5936594D220A1A7A00C0365F /* SpeechProcessors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechProcessors.swift; sourceTree = "<group>"; };
 		5937579222D5281900AA7516 /* VADDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VADDelegate.swift; sourceTree = "<group>"; };
-		593B1D5322C50A0E004D938E /* complex_fft.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = complex_fft.c; path = filter_audio/other/complex_fft.c; sourceTree = "<group>"; };
-		593B1D5422C50A0E004D938E /* complex_bit_reverse.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = complex_bit_reverse.c; path = filter_audio/other/complex_bit_reverse.c; sourceTree = "<group>"; };
-		593B1D5622C50A0E004D938E /* copy_set_operations.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = copy_set_operations.c; path = filter_audio/other/copy_set_operations.c; sourceTree = "<group>"; };
-		593B1D5B22C50A93004D938E /* real_fft.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = real_fft.c; path = filter_audio/other/real_fft.c; sourceTree = "<group>"; };
-		593B1D5C22C50A93004D938E /* vector_scaling_operations.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = vector_scaling_operations.c; path = filter_audio/other/vector_scaling_operations.c; sourceTree = "<group>"; };
-		593B1D5D22C50A93004D938E /* spl_sqrt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = spl_sqrt.c; path = filter_audio/other/spl_sqrt.c; sourceTree = "<group>"; };
-		593B1D5E22C50A93004D938E /* resample_by_2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = resample_by_2.c; path = filter_audio/other/resample_by_2.c; sourceTree = "<group>"; };
-		593B1D5F22C50A94004D938E /* resample_fractional.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = resample_fractional.c; path = filter_audio/other/resample_fractional.c; sourceTree = "<group>"; };
-		593B1D6022C50A94004D938E /* resample_by_2_internal.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = resample_by_2_internal.c; path = filter_audio/other/resample_by_2_internal.c; sourceTree = "<group>"; };
-		593B1D6122C50A94004D938E /* dot_product_with_scale.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = dot_product_with_scale.c; path = filter_audio/other/dot_product_with_scale.c; sourceTree = "<group>"; };
-		593B1D6222C50A94004D938E /* get_scaling_square.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = get_scaling_square.c; path = filter_audio/other/get_scaling_square.c; sourceTree = "<group>"; };
-		593B1D6322C50A94004D938E /* spl_init.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = spl_init.c; path = filter_audio/other/spl_init.c; sourceTree = "<group>"; };
-		593B1D6422C50A94004D938E /* division_operations.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = division_operations.c; path = filter_audio/other/division_operations.c; sourceTree = "<group>"; };
-		593B1D6522C50A94004D938E /* resample_48khz.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = resample_48khz.c; path = filter_audio/other/resample_48khz.c; sourceTree = "<group>"; };
-		593B1D6622C50A95004D938E /* downsample_fast.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = downsample_fast.c; path = filter_audio/other/downsample_fast.c; sourceTree = "<group>"; };
-		593B1D6722C50A95004D938E /* energy.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = energy.c; path = filter_audio/other/energy.c; sourceTree = "<group>"; };
-		593B1D6822C50A95004D938E /* min_max_operations.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = min_max_operations.c; path = filter_audio/other/min_max_operations.c; sourceTree = "<group>"; };
-		593B1D7722C50AB4004D938E /* analog_agc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = analog_agc.c; path = filter_audio/agc/analog_agc.c; sourceTree = "<group>"; };
-		593B1D7822C50AB4004D938E /* digital_agc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = digital_agc.c; path = filter_audio/agc/digital_agc.c; sourceTree = "<group>"; };
-		593B1D7B22C50AF2004D938E /* vad_filterbank.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = vad_filterbank.c; path = filter_audio/vad/vad_filterbank.c; sourceTree = "<group>"; };
-		593B1D7C22C50AF2004D938E /* vad_core.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = vad_core.h; path = filter_audio/vad/vad_core.h; sourceTree = "<group>"; };
-		593B1D7D22C50AF2004D938E /* vad_gmm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = vad_gmm.c; path = filter_audio/vad/vad_gmm.c; sourceTree = "<group>"; };
-		593B1D7E22C50AF2004D938E /* vad_sp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = vad_sp.c; path = filter_audio/vad/vad_sp.c; sourceTree = "<group>"; };
-		593B1D7F22C50AF2004D938E /* vad_core.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = vad_core.c; path = filter_audio/vad/vad_core.c; sourceTree = "<group>"; };
-		593B1D8022C50AF3004D938E /* webrtc_vad.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = webrtc_vad.c; path = filter_audio/vad/webrtc_vad.c; sourceTree = "<group>"; };
-		593B1D8722C5401C004D938E /* cross_correlation.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = cross_correlation.c; path = filter_audio/other/cross_correlation.c; sourceTree = "<group>"; };
-		593B1D8922CA8EDC004D938E /* webrtc_vad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = webrtc_vad.h; path = filter_audio/vad/include/webrtc_vad.h; sourceTree = "<group>"; };
-		593B1D8B22CA9243004D938E /* WebRTCVAD.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebRTCVAD.swift; sourceTree = "<group>"; };
-		593B1D8D22CA965A004D938E /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; name = module.modulemap; path = filter_audio/module.modulemap; sourceTree = "<group>"; };
 		594154B722F8AD2200E3624E /* TFLiteWakewordRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TFLiteWakewordRecognizer.swift; sourceTree = "<group>"; };
 		5967108D21F7AE6B00CBFC88 /* AppleSpeechRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSpeechRecognizer.swift; sourceTree = "<group>"; };
 		59A0D5BD2204E786003709C3 /* AppleViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppleViewController.swift; sourceTree = "<group>"; };
@@ -213,6 +248,98 @@
 		59A0D5C32204E799003709C3 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		59A0D5C52204E8E4003709C3 /* SpeechConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpeechConfiguration.swift; sourceTree = "<group>"; };
 		59A45E4E2243ED530089D023 /* PipelineDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PipelineDelegate.swift; sourceTree = "<group>"; };
+		59BCF87F234293D4008C5806 /* filter_audio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = filter_audio.h; sourceTree = "<group>"; };
+		59BCF884234293D4008C5806 /* ns_core.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ns_core.h; sourceTree = "<group>"; };
+		59BCF885234293D4008C5806 /* nsx_core.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = nsx_core.c; sourceTree = "<group>"; };
+		59BCF886234293D4008C5806 /* noise_suppression_x.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = noise_suppression_x.c; sourceTree = "<group>"; };
+		59BCF888234293D4008C5806 /* noise_suppression.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = noise_suppression.h; sourceTree = "<group>"; };
+		59BCF889234293D4008C5806 /* noise_suppression_x.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = noise_suppression_x.h; sourceTree = "<group>"; };
+		59BCF88A234293D4008C5806 /* nsx_core_c.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = nsx_core_c.c; sourceTree = "<group>"; };
+		59BCF88B234293D4008C5806 /* defines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = defines.h; sourceTree = "<group>"; };
+		59BCF88C234293D4008C5806 /* ns_core.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ns_core.c; sourceTree = "<group>"; };
+		59BCF88D234293D4008C5806 /* nsx_core.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = nsx_core.h; sourceTree = "<group>"; };
+		59BCF88E234293D4008C5806 /* windows_private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = windows_private.h; sourceTree = "<group>"; };
+		59BCF88F234293D4008C5806 /* noise_suppression.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = noise_suppression.c; sourceTree = "<group>"; };
+		59BCF890234293D4008C5806 /* nsx_defines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = nsx_defines.h; sourceTree = "<group>"; };
+		59BCF892234293D4008C5806 /* filteraudio.pc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = filteraudio.pc; sourceTree = "<group>"; };
+		59BCF894234293D4008C5806 /* complex_fft_tables.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = complex_fft_tables.h; sourceTree = "<group>"; };
+		59BCF895234293D4008C5806 /* complex_fft.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = complex_fft.c; sourceTree = "<group>"; };
+		59BCF896234293D4008C5806 /* signal_processing_library.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = signal_processing_library.h; sourceTree = "<group>"; };
+		59BCF897234293D4008C5806 /* stack_alloc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stack_alloc.h; sourceTree = "<group>"; };
+		59BCF898234293D4008C5806 /* resample_by_2_internal.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = resample_by_2_internal.c; sourceTree = "<group>"; };
+		59BCF899234293D4008C5806 /* speex_resampler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = speex_resampler.h; sourceTree = "<group>"; };
+		59BCF89A234293D4008C5806 /* energy.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = energy.c; sourceTree = "<group>"; };
+		59BCF89B234293D4008C5806 /* downsample_fast.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = downsample_fast.c; sourceTree = "<group>"; };
+		59BCF89C234293D4008C5806 /* splitting_filter.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = splitting_filter.c; sourceTree = "<group>"; };
+		59BCF89D234293D4008C5806 /* spl_init.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = spl_init.c; sourceTree = "<group>"; };
+		59BCF89E234293D4008C5806 /* fft4g.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = fft4g.c; sourceTree = "<group>"; };
+		59BCF89F234293D4008C5806 /* delay_estimator_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = delay_estimator_internal.h; sourceTree = "<group>"; };
+		59BCF8A0234293D4008C5806 /* cross_correlation.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cross_correlation.c; sourceTree = "<group>"; };
+		59BCF8A1234293D4008C5806 /* ring_buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ring_buffer.h; sourceTree = "<group>"; };
+		59BCF8A2234293D4008C5806 /* real_fft.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = real_fft.h; sourceTree = "<group>"; };
+		59BCF8A3234293D4008C5806 /* division_operations.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = division_operations.c; sourceTree = "<group>"; };
+		59BCF8A4234293D4008C5806 /* get_scaling_square.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = get_scaling_square.c; sourceTree = "<group>"; };
+		59BCF8A5234293D4008C5806 /* spl_inl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spl_inl.h; sourceTree = "<group>"; };
+		59BCF8A6234293D4008C5806 /* spl_sqrt_floor.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = spl_sqrt_floor.c; sourceTree = "<group>"; };
+		59BCF8A7234293D4008C5806 /* delay_estimator_wrapper.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = delay_estimator_wrapper.c; sourceTree = "<group>"; };
+		59BCF8A8234293D4008C5806 /* delay_estimator.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = delay_estimator.c; sourceTree = "<group>"; };
+		59BCF8A9234293D4008C5806 /* high_pass_filter.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = high_pass_filter.c; sourceTree = "<group>"; };
+		59BCF8AA234293D4008C5806 /* speex_resampler.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = speex_resampler.c; sourceTree = "<group>"; };
+		59BCF8AB234293D4008C5806 /* resample_by_2_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = resample_by_2_internal.h; sourceTree = "<group>"; };
+		59BCF8AC234293D4008C5806 /* min_max_operations.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = min_max_operations.c; sourceTree = "<group>"; };
+		59BCF8AD234293D4008C5806 /* fft4g.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fft4g.h; sourceTree = "<group>"; };
+		59BCF8AE234293D4008C5806 /* vector_scaling_operations.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vector_scaling_operations.c; sourceTree = "<group>"; };
+		59BCF8AF234293D4008C5806 /* resample_fractional.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = resample_fractional.c; sourceTree = "<group>"; };
+		59BCF8B0234293D4008C5806 /* real_fft.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = real_fft.c; sourceTree = "<group>"; };
+		59BCF8B1234293D4008C5806 /* complex_bit_reverse.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = complex_bit_reverse.c; sourceTree = "<group>"; };
+		59BCF8B2234293D4008C5806 /* ring_buffer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ring_buffer.c; sourceTree = "<group>"; };
+		59BCF8B3234293D4008C5806 /* randomization_functions.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = randomization_functions.c; sourceTree = "<group>"; };
+		59BCF8B4234293D4008C5806 /* dot_product_with_scale.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dot_product_with_scale.c; sourceTree = "<group>"; };
+		59BCF8B5234293D4008C5806 /* float_util.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = float_util.c; sourceTree = "<group>"; };
+		59BCF8B6234293D4008C5806 /* delay_estimator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = delay_estimator.h; sourceTree = "<group>"; };
+		59BCF8B7234293D4008C5806 /* delay_estimator_wrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = delay_estimator_wrapper.h; sourceTree = "<group>"; };
+		59BCF8B8234293D4008C5806 /* copy_set_operations.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = copy_set_operations.c; sourceTree = "<group>"; };
+		59BCF8B9234293D4008C5806 /* resample_by_2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = resample_by_2.c; sourceTree = "<group>"; };
+		59BCF8BA234293D4008C5806 /* resample_sse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = resample_sse.h; sourceTree = "<group>"; };
+		59BCF8BB234293D4008C5806 /* resample_48khz.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = resample_48khz.c; sourceTree = "<group>"; };
+		59BCF8BC234293D4008C5806 /* arch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = arch.h; sourceTree = "<group>"; };
+		59BCF8BD234293D4008C5806 /* spl_sqrt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = spl_sqrt.c; sourceTree = "<group>"; };
+		59BCF8BF234293D4008C5806 /* aec_core_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = aec_core_sse2.c; sourceTree = "<group>"; };
+		59BCF8C0234293D4008C5806 /* aec_core.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = aec_core.c; sourceTree = "<group>"; };
+		59BCF8C1234293D4008C5806 /* echo_cancellation_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = echo_cancellation_internal.h; sourceTree = "<group>"; };
+		59BCF8C2234293D4008C5806 /* aec_rdft.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aec_rdft.h; sourceTree = "<group>"; };
+		59BCF8C4234293D4008C5806 /* echo_cancellation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = echo_cancellation.h; sourceTree = "<group>"; };
+		59BCF8C5234293D4008C5806 /* aec_resampler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aec_resampler.h; sourceTree = "<group>"; };
+		59BCF8C6234293D4008C5806 /* aec_core_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aec_core_internal.h; sourceTree = "<group>"; };
+		59BCF8C7234293D4008C5806 /* aec_rdft_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = aec_rdft_sse2.c; sourceTree = "<group>"; };
+		59BCF8C8234293D4008C5806 /* aec_core.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aec_core.h; sourceTree = "<group>"; };
+		59BCF8C9234293D4008C5806 /* aec_rdft.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = aec_rdft.c; sourceTree = "<group>"; };
+		59BCF8CA234293D4008C5806 /* aec_resampler.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = aec_resampler.c; sourceTree = "<group>"; };
+		59BCF8CB234293D4008C5806 /* echo_cancellation.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = echo_cancellation.c; sourceTree = "<group>"; };
+		59BCF8CC234293D4008C5806 /* aec_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aec_common.h; sourceTree = "<group>"; };
+		59BCF8CE234293D4008C5806 /* filters.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = filters.c; sourceTree = "<group>"; };
+		59BCF8CF234293D4008C5806 /* filters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = filters.h; sourceTree = "<group>"; };
+		59BCF8D0234293D4008C5806 /* README */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README; sourceTree = "<group>"; };
+		59BCF8D3234293D4008C5806 /* gain_control.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gain_control.h; sourceTree = "<group>"; };
+		59BCF8D4234293D4008C5806 /* analog_agc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = analog_agc.h; sourceTree = "<group>"; };
+		59BCF8D5234293D4008C5806 /* digital_agc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = digital_agc.h; sourceTree = "<group>"; };
+		59BCF8D6234293D4008C5806 /* analog_agc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = analog_agc.c; sourceTree = "<group>"; };
+		59BCF8D7234293D4008C5806 /* digital_agc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = digital_agc.c; sourceTree = "<group>"; };
+		59BCF8D8234293D4008C5806 /* filter_audio.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = filter_audio.c; sourceTree = "<group>"; };
+		59BCF8D9234293D4008C5806 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
+		59BCF8DB234293D4008C5806 /* vad_sp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vad_sp.c; sourceTree = "<group>"; };
+		59BCF8DC234293D4008C5806 /* webrtc_vad.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = webrtc_vad.c; sourceTree = "<group>"; };
+		59BCF8DD234293D4008C5806 /* vad_core.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vad_core.h; sourceTree = "<group>"; };
+		59BCF8DF234293D4008C5806 /* vad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vad.h; sourceTree = "<group>"; };
+		59BCF8E0234293D4008C5806 /* webrtc_vad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = webrtc_vad.h; sourceTree = "<group>"; };
+		59BCF8E2234293D4008C5806 /* mock_vad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mock_vad.h; sourceTree = "<group>"; };
+		59BCF8E3234293D4008C5806 /* vad_gmm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vad_gmm.h; sourceTree = "<group>"; };
+		59BCF8E4234293D4008C5806 /* vad_filterbank.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vad_filterbank.c; sourceTree = "<group>"; };
+		59BCF8E5234293D4008C5806 /* vad_core.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vad_core.c; sourceTree = "<group>"; };
+		59BCF8E6234293D4008C5806 /* vad_sp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vad_sp.h; sourceTree = "<group>"; };
+		59BCF8E7234293D4008C5806 /* vad_filterbank.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vad_filterbank.h; sourceTree = "<group>"; };
+		59BCF8E8234293D4008C5806 /* vad_gmm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vad_gmm.c; sourceTree = "<group>"; };
+		59BCF946234293EE008C5806 /* WebRTCVAD.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WebRTCVAD.swift; path = SpokeStack/WebRTCVAD.swift; sourceTree = SOURCE_ROOT; };
 		59C2AFD92319CB7100E47AC5 /* RingBufferTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RingBufferTest.swift; sourceTree = "<group>"; };
 		59C2AFED231ED07100E47AC5 /* WebRTCVADTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebRTCVADTest.swift; sourceTree = "<group>"; };
 		59D78F5E2322D13700728A98 /* AudioControllerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioControllerTest.swift; sourceTree = "<group>"; };
@@ -435,7 +562,7 @@
 		59062EFD22A5AA6C00613AD8 /* VAD */ = {
 			isa = PBXGroup;
 			children = (
-				593B1D5222C509FF004D938E /* filter_audio */,
+				59BCF87E234293D4008C5806 /* filter_audio */,
 				593757AA22D68A9500AA7516 /* Wit */,
 			);
 			path = VAD;
@@ -464,41 +591,191 @@
 			path = Wit;
 			sourceTree = "<group>";
 		};
-		593B1D5222C509FF004D938E /* filter_audio */ = {
+		59BCF87E234293D4008C5806 /* filter_audio */ = {
 			isa = PBXGroup;
 			children = (
-				593B1D8D22CA965A004D938E /* module.modulemap */,
-				593B1D7722C50AB4004D938E /* analog_agc.c */,
-				593B1D7822C50AB4004D938E /* digital_agc.c */,
-				593B1D5422C50A0E004D938E /* complex_bit_reverse.c */,
-				593B1D5322C50A0E004D938E /* complex_fft.c */,
-				593B1D5622C50A0E004D938E /* copy_set_operations.c */,
-				593B1D8722C5401C004D938E /* cross_correlation.c */,
-				593B1D6422C50A94004D938E /* division_operations.c */,
-				593B1D6122C50A94004D938E /* dot_product_with_scale.c */,
-				593B1D6622C50A95004D938E /* downsample_fast.c */,
-				593B1D6722C50A95004D938E /* energy.c */,
-				593B1D6222C50A94004D938E /* get_scaling_square.c */,
-				593B1D6822C50A95004D938E /* min_max_operations.c */,
-				593B1D5B22C50A93004D938E /* real_fft.c */,
-				593B1D6522C50A94004D938E /* resample_48khz.c */,
-				593B1D6022C50A94004D938E /* resample_by_2_internal.c */,
-				593B1D5E22C50A93004D938E /* resample_by_2.c */,
-				593B1D5F22C50A94004D938E /* resample_fractional.c */,
-				593B1D6322C50A94004D938E /* spl_init.c */,
-				593B1D5D22C50A93004D938E /* spl_sqrt.c */,
-				593B1D7F22C50AF2004D938E /* vad_core.c */,
-				593B1D7C22C50AF2004D938E /* vad_core.h */,
-				593B1D7B22C50AF2004D938E /* vad_filterbank.c */,
-				593B1D7D22C50AF2004D938E /* vad_gmm.c */,
-				593B1D7E22C50AF2004D938E /* vad_sp.c */,
-				593B1D5C22C50A93004D938E /* vector_scaling_operations.c */,
-				593B1D8922CA8EDC004D938E /* webrtc_vad.h */,
-				593B1D8022C50AF3004D938E /* webrtc_vad.c */,
-				593B1D8B22CA9243004D938E /* WebRTCVAD.swift */,
+				59BCF946234293EE008C5806 /* WebRTCVAD.swift */,
+				59BCF87F234293D4008C5806 /* filter_audio.h */,
+				59BCF883234293D4008C5806 /* ns */,
+				59BCF892234293D4008C5806 /* filteraudio.pc */,
+				59BCF893234293D4008C5806 /* other */,
+				59BCF8BE234293D4008C5806 /* aec */,
+				59BCF8CD234293D4008C5806 /* zam */,
+				59BCF8D0234293D4008C5806 /* README */,
+				59BCF8D1234293D4008C5806 /* agc */,
+				59BCF8D8234293D4008C5806 /* filter_audio.c */,
+				59BCF8D9234293D4008C5806 /* module.modulemap */,
+				59BCF8DA234293D4008C5806 /* vad */,
 			);
-			name = filter_audio;
-			path = ..;
+			path = filter_audio;
+			sourceTree = "<group>";
+		};
+		59BCF883234293D4008C5806 /* ns */ = {
+			isa = PBXGroup;
+			children = (
+				59BCF884234293D4008C5806 /* ns_core.h */,
+				59BCF885234293D4008C5806 /* nsx_core.c */,
+				59BCF886234293D4008C5806 /* noise_suppression_x.c */,
+				59BCF887234293D4008C5806 /* include */,
+				59BCF88A234293D4008C5806 /* nsx_core_c.c */,
+				59BCF88B234293D4008C5806 /* defines.h */,
+				59BCF88C234293D4008C5806 /* ns_core.c */,
+				59BCF88D234293D4008C5806 /* nsx_core.h */,
+				59BCF88E234293D4008C5806 /* windows_private.h */,
+				59BCF88F234293D4008C5806 /* noise_suppression.c */,
+				59BCF890234293D4008C5806 /* nsx_defines.h */,
+			);
+			path = ns;
+			sourceTree = "<group>";
+		};
+		59BCF887234293D4008C5806 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				59BCF888234293D4008C5806 /* noise_suppression.h */,
+				59BCF889234293D4008C5806 /* noise_suppression_x.h */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
+		59BCF893234293D4008C5806 /* other */ = {
+			isa = PBXGroup;
+			children = (
+				59BCF894234293D4008C5806 /* complex_fft_tables.h */,
+				59BCF895234293D4008C5806 /* complex_fft.c */,
+				59BCF896234293D4008C5806 /* signal_processing_library.h */,
+				59BCF897234293D4008C5806 /* stack_alloc.h */,
+				59BCF898234293D4008C5806 /* resample_by_2_internal.c */,
+				59BCF899234293D4008C5806 /* speex_resampler.h */,
+				59BCF89A234293D4008C5806 /* energy.c */,
+				59BCF89B234293D4008C5806 /* downsample_fast.c */,
+				59BCF89C234293D4008C5806 /* splitting_filter.c */,
+				59BCF89D234293D4008C5806 /* spl_init.c */,
+				59BCF89E234293D4008C5806 /* fft4g.c */,
+				59BCF89F234293D4008C5806 /* delay_estimator_internal.h */,
+				59BCF8A0234293D4008C5806 /* cross_correlation.c */,
+				59BCF8A1234293D4008C5806 /* ring_buffer.h */,
+				59BCF8A2234293D4008C5806 /* real_fft.h */,
+				59BCF8A3234293D4008C5806 /* division_operations.c */,
+				59BCF8A4234293D4008C5806 /* get_scaling_square.c */,
+				59BCF8A5234293D4008C5806 /* spl_inl.h */,
+				59BCF8A6234293D4008C5806 /* spl_sqrt_floor.c */,
+				59BCF8A7234293D4008C5806 /* delay_estimator_wrapper.c */,
+				59BCF8A8234293D4008C5806 /* delay_estimator.c */,
+				59BCF8A9234293D4008C5806 /* high_pass_filter.c */,
+				59BCF8AA234293D4008C5806 /* speex_resampler.c */,
+				59BCF8AB234293D4008C5806 /* resample_by_2_internal.h */,
+				59BCF8AC234293D4008C5806 /* min_max_operations.c */,
+				59BCF8AD234293D4008C5806 /* fft4g.h */,
+				59BCF8AE234293D4008C5806 /* vector_scaling_operations.c */,
+				59BCF8AF234293D4008C5806 /* resample_fractional.c */,
+				59BCF8B0234293D4008C5806 /* real_fft.c */,
+				59BCF8B1234293D4008C5806 /* complex_bit_reverse.c */,
+				59BCF8B2234293D4008C5806 /* ring_buffer.c */,
+				59BCF8B3234293D4008C5806 /* randomization_functions.c */,
+				59BCF8B4234293D4008C5806 /* dot_product_with_scale.c */,
+				59BCF8B5234293D4008C5806 /* float_util.c */,
+				59BCF8B6234293D4008C5806 /* delay_estimator.h */,
+				59BCF8B7234293D4008C5806 /* delay_estimator_wrapper.h */,
+				59BCF8B8234293D4008C5806 /* copy_set_operations.c */,
+				59BCF8B9234293D4008C5806 /* resample_by_2.c */,
+				59BCF8BA234293D4008C5806 /* resample_sse.h */,
+				59BCF8BB234293D4008C5806 /* resample_48khz.c */,
+				59BCF8BC234293D4008C5806 /* arch.h */,
+				59BCF8BD234293D4008C5806 /* spl_sqrt.c */,
+			);
+			path = other;
+			sourceTree = "<group>";
+		};
+		59BCF8BE234293D4008C5806 /* aec */ = {
+			isa = PBXGroup;
+			children = (
+				59BCF8BF234293D4008C5806 /* aec_core_sse2.c */,
+				59BCF8C0234293D4008C5806 /* aec_core.c */,
+				59BCF8C1234293D4008C5806 /* echo_cancellation_internal.h */,
+				59BCF8C2234293D4008C5806 /* aec_rdft.h */,
+				59BCF8C3234293D4008C5806 /* include */,
+				59BCF8C5234293D4008C5806 /* aec_resampler.h */,
+				59BCF8C6234293D4008C5806 /* aec_core_internal.h */,
+				59BCF8C7234293D4008C5806 /* aec_rdft_sse2.c */,
+				59BCF8C8234293D4008C5806 /* aec_core.h */,
+				59BCF8C9234293D4008C5806 /* aec_rdft.c */,
+				59BCF8CA234293D4008C5806 /* aec_resampler.c */,
+				59BCF8CB234293D4008C5806 /* echo_cancellation.c */,
+				59BCF8CC234293D4008C5806 /* aec_common.h */,
+			);
+			path = aec;
+			sourceTree = "<group>";
+		};
+		59BCF8C3234293D4008C5806 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				59BCF8C4234293D4008C5806 /* echo_cancellation.h */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
+		59BCF8CD234293D4008C5806 /* zam */ = {
+			isa = PBXGroup;
+			children = (
+				59BCF8CE234293D4008C5806 /* filters.c */,
+				59BCF8CF234293D4008C5806 /* filters.h */,
+			);
+			path = zam;
+			sourceTree = "<group>";
+		};
+		59BCF8D1234293D4008C5806 /* agc */ = {
+			isa = PBXGroup;
+			children = (
+				59BCF8D2234293D4008C5806 /* include */,
+				59BCF8D4234293D4008C5806 /* analog_agc.h */,
+				59BCF8D5234293D4008C5806 /* digital_agc.h */,
+				59BCF8D6234293D4008C5806 /* analog_agc.c */,
+				59BCF8D7234293D4008C5806 /* digital_agc.c */,
+			);
+			path = agc;
+			sourceTree = "<group>";
+		};
+		59BCF8D2234293D4008C5806 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				59BCF8D3234293D4008C5806 /* gain_control.h */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
+		59BCF8DA234293D4008C5806 /* vad */ = {
+			isa = PBXGroup;
+			children = (
+				59BCF8DB234293D4008C5806 /* vad_sp.c */,
+				59BCF8DC234293D4008C5806 /* webrtc_vad.c */,
+				59BCF8DD234293D4008C5806 /* vad_core.h */,
+				59BCF8DE234293D4008C5806 /* include */,
+				59BCF8E1234293D4008C5806 /* mock */,
+				59BCF8E3234293D4008C5806 /* vad_gmm.h */,
+				59BCF8E4234293D4008C5806 /* vad_filterbank.c */,
+				59BCF8E5234293D4008C5806 /* vad_core.c */,
+				59BCF8E6234293D4008C5806 /* vad_sp.h */,
+				59BCF8E7234293D4008C5806 /* vad_filterbank.h */,
+				59BCF8E8234293D4008C5806 /* vad_gmm.c */,
+			);
+			path = vad;
+			sourceTree = "<group>";
+		};
+		59BCF8DE234293D4008C5806 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				59BCF8DF234293D4008C5806 /* vad.h */,
+				59BCF8E0234293D4008C5806 /* webrtc_vad.h */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
+		59BCF8E1234293D4008C5806 /* mock */ = {
+			isa = PBXGroup;
+			children = (
+				59BCF8E2234293D4008C5806 /* mock_vad.h */,
+			);
+			path = mock;
 			sourceTree = "<group>";
 		};
 		59FB0C8922AEE4DA00FB9662 /* Extensions */ = {
@@ -538,7 +815,47 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				59BCF8EC234293D4008C5806 /* ns_core.h in Headers */,
+				59BCF936234293D4008C5806 /* digital_agc.h in Headers */,
+				59BCF926234293D4008C5806 /* echo_cancellation_internal.h in Headers */,
+				59BCF928234293D4008C5806 /* echo_cancellation.h in Headers */,
+				59BCF93C234293D4008C5806 /* vad_core.h in Headers */,
+				59BCF934234293D4008C5806 /* gain_control.h in Headers */,
+				59BCF8F2234293D4008C5806 /* defines.h in Headers */,
+				59BCF93E234293D4008C5806 /* webrtc_vad.h in Headers */,
+				59BCF8F0234293D4008C5806 /* noise_suppression_x.h in Headers */,
+				59BCF908234293D4008C5806 /* real_fft.h in Headers */,
+				59BCF940234293D4008C5806 /* vad_gmm.h in Headers */,
+				59BCF943234293D4008C5806 /* vad_sp.h in Headers */,
+				59BCF93F234293D4008C5806 /* mock_vad.h in Headers */,
+				59BCF8FA234293D4008C5806 /* complex_fft_tables.h in Headers */,
+				59BCF90B234293D4008C5806 /* spl_inl.h in Headers */,
+				59BCF913234293D4008C5806 /* fft4g.h in Headers */,
+				59BCF8EF234293D4008C5806 /* noise_suppression.h in Headers */,
+				59BCF927234293D4008C5806 /* aec_rdft.h in Headers */,
+				59BCF8F5234293D4008C5806 /* windows_private.h in Headers */,
+				59BCF905234293D4008C5806 /* delay_estimator_internal.h in Headers */,
+				59BCF935234293D4008C5806 /* analog_agc.h in Headers */,
+				59BCF907234293D4008C5806 /* ring_buffer.h in Headers */,
+				59BCF92A234293D4008C5806 /* aec_core_internal.h in Headers */,
+				59BCF8FF234293D4008C5806 /* speex_resampler.h in Headers */,
+				59BCF8F7234293D4008C5806 /* nsx_defines.h in Headers */,
+				59BCF8FC234293D4008C5806 /* signal_processing_library.h in Headers */,
+				59BCF929234293D4008C5806 /* aec_resampler.h in Headers */,
 				01D31F4C216BAF260055FD45 /* SpokeStack.h in Headers */,
+				59BCF911234293D4008C5806 /* resample_by_2_internal.h in Headers */,
+				59BCF8E9234293D4008C5806 /* filter_audio.h in Headers */,
+				59BCF92C234293D4008C5806 /* aec_core.h in Headers */,
+				59BCF91D234293D4008C5806 /* delay_estimator_wrapper.h in Headers */,
+				59BCF91C234293D4008C5806 /* delay_estimator.h in Headers */,
+				59BCF932234293D4008C5806 /* filters.h in Headers */,
+				59BCF944234293D4008C5806 /* vad_filterbank.h in Headers */,
+				59BCF93D234293D4008C5806 /* vad.h in Headers */,
+				59BCF930234293D4008C5806 /* aec_common.h in Headers */,
+				59BCF8F4234293D4008C5806 /* nsx_core.h in Headers */,
+				59BCF8FD234293D4008C5806 /* stack_alloc.h in Headers */,
+				59BCF920234293D4008C5806 /* resample_sse.h in Headers */,
+				59BCF922234293D4008C5806 /* arch.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -669,6 +986,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				59BCF933234293D4008C5806 /* README in Resources */,
+				59BCF8F9234293D4008C5806 /* filteraudio.pc in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -768,57 +1087,80 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				59BCF931234293D4008C5806 /* filters.c in Sources */,
+				59BCF937234293D4008C5806 /* analog_agc.c in Sources */,
+				59BCF90E234293D4008C5806 /* delay_estimator.c in Sources */,
+				59BCF919234293D4008C5806 /* randomization_functions.c in Sources */,
+				59BCF92E234293D4008C5806 /* aec_resampler.c in Sources */,
 				59365948220889EE00C0365F /* AppleWakewordRecognizer.swift in Sources */,
-				593B1D7422C50A95004D938E /* downsample_fast.c in Sources */,
+				59BCF916234293D4008C5806 /* real_fft.c in Sources */,
 				59FB0C8822A98E1900FB9662 /* CoreMLWakewordRecognizer.swift in Sources */,
-				593B1D6F22C50A95004D938E /* dot_product_with_scale.c in Sources */,
-				593B1D8622C50AF3004D938E /* webrtc_vad.c in Sources */,
-				593B1D7322C50A95004D938E /* resample_48khz.c in Sources */,
-				593B1D6A22C50A95004D938E /* vector_scaling_operations.c in Sources */,
 				01D31F6F216BAFD90055FD45 /* SpeechContext.swift in Sources */,
+				59BCF90C234293D4008C5806 /* spl_sqrt_floor.c in Sources */,
+				59BCF8F3234293D4008C5806 /* ns_core.c in Sources */,
 				59E0E1372301F0A80060F012 /* Trace.swift in Sources */,
+				59BCF91E234293D4008C5806 /* copy_set_operations.c in Sources */,
+				59BCF8F1234293D4008C5806 /* nsx_core_c.c in Sources */,
+				59BCF938234293D4008C5806 /* digital_agc.c in Sources */,
+				59BCF900234293D4008C5806 /* energy.c in Sources */,
+				59BCF925234293D4008C5806 /* aec_core.c in Sources */,
+				59BCF93A234293D4008C5806 /* vad_sp.c in Sources */,
+				59BCF906234293D4008C5806 /* cross_correlation.c in Sources */,
 				59E0E13522FE2C2B0060F012 /* SignalProcessing.swift in Sources */,
+				59BCF93B234293D4008C5806 /* webrtc_vad.c in Sources */,
 				59A0D5C72204E8E4003709C3 /* SpeechConfiguration.swift in Sources */,
-				593B1D7222C50A95004D938E /* division_operations.c in Sources */,
-				593B1D8C22CA9243004D938E /* WebRTCVAD.swift in Sources */,
+				59BCF942234293D4008C5806 /* vad_core.c in Sources */,
 				59FB0C8D22B0640700FB9662 /* RingBuffer.swift in Sources */,
-				593B1D7522C50A95004D938E /* energy.c in Sources */,
-				593B1D8122C50AF3004D938E /* vad_filterbank.c in Sources */,
+				59BCF947234293EE008C5806 /* WebRTCVAD.swift in Sources */,
+				59BCF92B234293D4008C5806 /* aec_rdft_sse2.c in Sources */,
+				59BCF921234293D4008C5806 /* resample_48khz.c in Sources */,
+				59BCF902234293D4008C5806 /* splitting_filter.c in Sources */,
 				01D31F8E216BB0370055FD45 /* Typealiases.swift in Sources */,
-				593B1D8522C50AF3004D938E /* vad_core.c in Sources */,
-				593B1D6D22C50A95004D938E /* resample_fractional.c in Sources */,
 				01D31F66216BAFB50055FD45 /* Error.swift in Sources */,
 				01D31F6A216BAFC60055FD45 /* SpeechPipeline.swift in Sources */,
-				593B1D7922C50AB4004D938E /* analog_agc.c in Sources */,
-				593B1D5722C50A0E004D938E /* complex_fft.c in Sources */,
+				59BCF8FE234293D4008C5806 /* resample_by_2_internal.c in Sources */,
+				59BCF90A234293D4008C5806 /* get_scaling_square.c in Sources */,
 				5937579322D5281900AA7516 /* VADDelegate.swift in Sources */,
-				593B1D5822C50A0E004D938E /* complex_bit_reverse.c in Sources */,
-				593B1D6E22C50A95004D938E /* resample_by_2_internal.c in Sources */,
-				593B1D8822C5401D004D938E /* cross_correlation.c in Sources */,
+				59BCF909234293D4008C5806 /* division_operations.c in Sources */,
+				59BCF910234293D4008C5806 /* speex_resampler.c in Sources */,
 				5967108E21F7AE6B00CBFC88 /* AppleSpeechRecognizer.swift in Sources */,
+				59BCF92D234293D4008C5806 /* aec_rdft.c in Sources */,
 				5936594C2209EA1800C0365F /* SpeechProcessor.swift in Sources */,
-				593B1D7A22C50AB4004D938E /* digital_agc.c in Sources */,
+				59BCF914234293D4008C5806 /* vector_scaling_operations.c in Sources */,
 				594154B822F8AD2200E3624E /* TFLiteWakewordRecognizer.swift in Sources */,
-				593B1D7122C50A95004D938E /* spl_init.c in Sources */,
 				59FB0C8B22AEE4F100FB9662 /* Data+Extensions.swift in Sources */,
 				59FB0C9322B17A9A00FB9662 /* WakeWordFilter.mlmodel in Sources */,
-				593B1D6922C50A95004D938E /* real_fft.c in Sources */,
+				59BCF924234293D4008C5806 /* aec_core_sse2.c in Sources */,
+				59BCF918234293D4008C5806 /* ring_buffer.c in Sources */,
+				59BCF945234293D4008C5806 /* vad_gmm.c in Sources */,
 				59A45E4F2243ED530089D023 /* PipelineDelegate.swift in Sources */,
-				593B1D7022C50A95004D938E /* get_scaling_square.c in Sources */,
-				593B1D5A22C50A0E004D938E /* copy_set_operations.c in Sources */,
-				593B1D6C22C50A95004D938E /* resample_by_2.c in Sources */,
+				59BCF91F234293D4008C5806 /* resample_by_2.c in Sources */,
+				59BCF939234293D4008C5806 /* filter_audio.c in Sources */,
+				59BCF912234293D4008C5806 /* min_max_operations.c in Sources */,
+				59BCF923234293D4008C5806 /* spl_sqrt.c in Sources */,
+				59BCF915234293D4008C5806 /* resample_fractional.c in Sources */,
 				01D31F62216BAFA40055FD45 /* AudioController.swift in Sources */,
-				593B1D6B22C50A95004D938E /* spl_sqrt.c in Sources */,
-				593B1D8322C50AF3004D938E /* vad_gmm.c in Sources */,
+				59BCF901234293D4008C5806 /* downsample_fast.c in Sources */,
+				59BCF8FB234293D4008C5806 /* complex_fft.c in Sources */,
+				59BCF91A234293D4008C5806 /* dot_product_with_scale.c in Sources */,
+				59BCF90D234293D4008C5806 /* delay_estimator_wrapper.c in Sources */,
 				5936594E220A1A7A00C0365F /* SpeechProcessors.swift in Sources */,
+				59BCF941234293D4008C5806 /* vad_filterbank.c in Sources */,
+				59BCF903234293D4008C5806 /* spl_init.c in Sources */,
+				59BCF8EE234293D4008C5806 /* noise_suppression_x.c in Sources */,
 				01D31F8A216BB0220055FD45 /* Results.swift in Sources */,
 				5936594A2209DDBA00C0365F /* SpeechEventListener.swift in Sources */,
+				59BCF8F6234293D4008C5806 /* noise_suppression.c in Sources */,
 				59FB0C9522B17AA300FB9662 /* WakeWordDetect.mlmodel in Sources */,
 				59FB0C8522A5C48B00FB9662 /* WITVad.m in Sources */,
+				59BCF917234293D4008C5806 /* complex_bit_reverse.c in Sources */,
 				01D31F79216BAFEF0055FD45 /* AudioControllerDelegate.swift in Sources */,
 				59FB0C8322A5C48400FB9662 /* WITCvad.m in Sources */,
-				593B1D8422C50AF3004D938E /* vad_sp.c in Sources */,
-				593B1D7622C50A95004D938E /* min_max_operations.c in Sources */,
+				59BCF8ED234293D4008C5806 /* nsx_core.c in Sources */,
+				59BCF92F234293D4008C5806 /* echo_cancellation.c in Sources */,
+				59BCF91B234293D4008C5806 /* float_util.c in Sources */,
+				59BCF904234293D4008C5806 /* fft4g.c in Sources */,
+				59BCF90F234293D4008C5806 /* high_pass_filter.c in Sources */,
 				59FB0C8F22B0682900FB9662 /* FFT.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -856,7 +1198,6 @@
 				59C2AFDB2319CE5800E47AC5 /* SpeechConfiguration.swift in Sources */,
 				59EF51C32332E57B006BA0BD /* Frame.swift in Sources */,
 				59EF51BF233013A9006BA0BD /* AppleSpeechRecognizerTest.swift in Sources */,
-				59C2AFE32319CEBC00E47AC5 /* WebRTCVAD.swift in Sources */,
 				01D31F67216BAFB50055FD45 /* Error.swift in Sources */,
 				59C2AFEB2319D05B00E47AC5 /* WakeWordDetect.mlmodel in Sources */,
 			);
@@ -1106,7 +1447,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SCAN_ALL_SOURCE_FILES_FOR_INCLUDES = YES;
 				SKIP_INSTALL = YES;
-				SWIFT_INCLUDE_PATHS = "${SRCROOT}/SpokeStack/filter_audio/** ${SRCROOT}/SpokeStack/VAD/Wit";
+				SWIFT_INCLUDE_PATHS = "${SRCROOT}/SpokeStack/VAD/filter_audio/** ${SRCROOT}/SpokeStack/VAD/Wit";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1149,7 +1490,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SCAN_ALL_SOURCE_FILES_FOR_INCLUDES = YES;
 				SKIP_INSTALL = YES;
-				SWIFT_INCLUDE_PATHS = "${SRCROOT}/SpokeStack/filter_audio/** ${SRCROOT}/SpokeStack/VAD/Wit";
+				SWIFT_INCLUDE_PATHS = "${SRCROOT}/SpokeStack/VAD/filter_audio/** ${SRCROOT}/SpokeStack/VAD/Wit";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = "";

--- a/SpokeStack.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/SpokeStack.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>PreviewsEnabled</key>
+	<false/>
+</dict>
 </plist>

--- a/SpokeStack/WebRTCVAD.swift
+++ b/SpokeStack/WebRTCVAD.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import WebRtcVad
+import filter_audio
 
 public enum VADMode: Int {
     case HighQuality

--- a/SpokeStack/WebRTCVAD.swift
+++ b/SpokeStack/WebRTCVAD.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import filter_audio
+import WebRtcVad
 
 public enum VADMode: Int {
     case HighQuality

--- a/SpokeStack/module.modulemap
+++ b/SpokeStack/module.modulemap
@@ -1,4 +1,0 @@
-module filter_audio {
-  header "vad/vad_core.h"
-  export *
-}


### PR DESCRIPTION
Using the newly published [`filter_audio`](https://github.com/pylon/filter_audio/tree/cocoapods) cocoapod, removes filter_audio (the WebRTC VAD) as a git submodule or copied code and instead as a cocoapod dependency. This creates consistency with how dependencies are managed (matching TensorFlowLite), and removes obstacles to publishing this project as a cocoapod.